### PR TITLE
Make error logs compact and readable without losing signal.

### DIFF
--- a/core/api/alexa/alexa.model.js
+++ b/core/api/alexa/alexa.model.js
@@ -228,8 +228,7 @@ module.exports = function AlexaModel(logger, db, redisClient, jwtService) {
           // report state
         } catch (e) {
           const status = get(e, 'response.status') || e.code;
-          const description =
-            get(e, 'response.data.payload.description') || get(e, 'response.statusText') || e.message;
+          const description = get(e, 'response.data.payload.description') || get(e, 'response.statusText') || e.message;
           logger.warn(`ALEXA_REPORT_STATE_ERROR user=${user.id} status=${status} message=${description}`);
         }
       });

--- a/core/api/alexa/alexa.model.js
+++ b/core/api/alexa/alexa.model.js
@@ -3,10 +3,10 @@ const crypto = require('crypto');
 const jwt = require('jsonwebtoken');
 const uuid = require('uuid');
 const get = require('get-value');
+const plainAxios = require('axios');
 const randomBytes = Promise.promisify(require('crypto').randomBytes);
 
 const axios = require('../../service/axios');
-const plainAxios = require('axios');
 const { ForbiddenError } = require('../../common/error');
 
 const ALEXA_OAUTH_CODE_REDIS_PREFIX = `ALEXA_OAUTH_CODE`;

--- a/core/api/alexa/alexa.model.js
+++ b/core/api/alexa/alexa.model.js
@@ -6,6 +6,7 @@ const get = require('get-value');
 const randomBytes = Promise.promisify(require('crypto').randomBytes);
 
 const axios = require('../../service/axios');
+const plainAxios = require('axios');
 const { ForbiddenError } = require('../../common/error');
 
 const ALEXA_OAUTH_CODE_REDIS_PREFIX = `ALEXA_OAUTH_CODE`;
@@ -223,10 +224,13 @@ module.exports = function AlexaModel(logger, db, redisClient, jwtService) {
             data: payload,
             url: 'https://api.eu.amazonalexa.com/v3/events',
           };
-          await axios(options);
+          await plainAxios(options);
           // report state
         } catch (e) {
-          logger.error(`ALEXA_REPORT_STATE_ERROR, user_id = ${users[0].id}`);
+          const status = get(e, 'response.status') || e.code;
+          const description =
+            get(e, 'response.data.payload.description') || get(e, 'response.statusText') || e.message;
+          logger.warn(`ALEXA_REPORT_STATE_ERROR user=${user.id} status=${status} message=${description}`);
         }
       });
     }

--- a/core/api/google/google.model.js
+++ b/core/api/google/google.model.js
@@ -177,11 +177,11 @@ module.exports = function GoogleHomeModel(logger, db, redisClient, jwtService) {
         });
       } catch (e) {
         const status = get(e, 'response.status');
-        logger.debug(`GOOGLE_HOME_REPORT_STATE_ERROR, user = ${users[0].id}, status = ${status}`);
-        if (status !== 404) {
-          logger.info(get(e, 'response.data'));
-          logger.info(payloadCleaned);
-        }
+        const message = get(e, 'response.data.error.message') || e.message;
+        const deviceIds = Object.keys(get(payloadCleaned, 'devices.states') || {});
+        logger.warn(
+          `GOOGLE_HOME_REPORT_STATE_ERROR user=${users[0].id} status=${status} message=${message} devices=${deviceIds.join(',') || '—'}`,
+        );
       }
     }
   }

--- a/core/api/google/google.model.js
+++ b/core/api/google/google.model.js
@@ -180,7 +180,9 @@ module.exports = function GoogleHomeModel(logger, db, redisClient, jwtService) {
         const message = get(e, 'response.data.error.message') || e.message;
         const deviceIds = Object.keys(get(payloadCleaned, 'devices.states') || {});
         logger.warn(
-          `GOOGLE_HOME_REPORT_STATE_ERROR user=${users[0].id} status=${status} message=${message} devices=${deviceIds.join(',') || '—'}`,
+          `GOOGLE_HOME_REPORT_STATE_ERROR user=${users[0].id} status=${status} message=${message} devices=${
+            deviceIds.join(',') || '—'
+          }`,
         );
       }
     }

--- a/core/api/socket/socket.model.js
+++ b/core/api/socket/socket.model.js
@@ -140,8 +140,7 @@ module.exports = function SocketModel(logger, db, redisClient, io, fingerprint, 
       if (socket.constructor.name === 'RemoteSocket') {
         io.serverSideEmit(SERVER_TO_SERVER_COMMUNICATION, { socket_id: socket.id, message }, (err, replies) => {
           if (err) {
-            logger.error('NO_INSTANCE_FOUND (error)');
-            logger.error(err);
+            logger.warn(`NO_INSTANCE_FOUND (error) user_id=${user.id}`);
             const notFound = new NotFoundError('NO_INSTANCE_FOUND');
             return callback(notFound.jsonError());
           }
@@ -150,7 +149,7 @@ module.exports = function SocketModel(logger, db, redisClient, io, fingerprint, 
           const filteredReplies = replies.filter((reply) => reply !== null);
 
           if (filteredReplies.length === 0) {
-            logger.error('NO_INSTANCE_FOUND (no replies)');
+            logger.warn(`NO_INSTANCE_FOUND (no replies) user_id=${user.id}`);
             const notFound = new NotFoundError('NO_INSTANCE_FOUND');
             return callback(notFound.jsonError());
           }
@@ -168,8 +167,15 @@ module.exports = function SocketModel(logger, db, redisClient, io, fingerprint, 
 
       return null;
     } catch (e) {
-      logger.error(`HANDLE_NEW_MESSAGE_FROM_USER_ERROR - user_id = ${user.id}`);
-      logger.error(e);
+      if (e.message === 'INSTANCE_NOT_FOUND') {
+        // Expected when the instance is offline — compact warn, no stack
+        logger.warn(`INSTANCE_NOT_FOUND user_id=${user.id}`);
+      } else {
+        logger.error(`HANDLE_NEW_MESSAGE_FROM_USER_ERROR user_id=${user.id}: ${e.message}`);
+        if (e.stack) {
+          logger.error(e.stack);
+        }
+      }
       const notFound = new NotFoundError('NO_INSTANCE_FOUND');
       return callback(notFound.jsonError());
     }

--- a/core/middleware/errorMiddleware.js
+++ b/core/middleware/errorMiddleware.js
@@ -10,25 +10,97 @@ const {
   TooManyRequestsError,
 } = require('../common/error');
 
+const EXPECTED_CLIENT_ERRORS = [
+  ValidationError,
+  AlreadyExistError,
+  NotFoundError,
+  ForbiddenError,
+  UnauthorizedError,
+  BadRequestError,
+  TooManyRequestsError,
+  PaymentRequiredError,
+];
+
+function isExpectedClientError(error) {
+  return EXPECTED_CLIENT_ERRORS.some((ErrorClass) => error instanceof ErrorClass);
+}
+
+function isAxiosError(error) {
+  return Boolean(error && (error.isAxiosError === true || error.name === 'AxiosError'));
+}
+
+function formatRequestContext(req) {
+  const method = req.method || '?';
+  const path = (req.route && req.route.path) || req.originalUrl || req.url || '?';
+  const userId = req.user && req.user.id ? req.user.id : '—';
+  return `${method} ${path} user=${userId}`;
+}
+
+function summarizeResponseData(data) {
+  if (data == null) {
+    return '';
+  }
+  if (typeof data === 'string') {
+    return data.slice(0, 200);
+  }
+  if (typeof data.error === 'string') {
+    return data.error.slice(0, 200);
+  }
+  if (data.error && data.error.message) {
+    return String(data.error.message).slice(0, 200);
+  }
+  if (data.message) {
+    return String(data.message).slice(0, 200);
+  }
+  try {
+    return JSON.stringify(data).slice(0, 200);
+  } catch (e) {
+    return '';
+  }
+}
+
+function formatAxiosError(error) {
+  const method = ((error.config && error.config.method) || '?').toUpperCase();
+  const url = (error.config && error.config.url) || '?';
+  const status = (error.response && error.response.status) || error.code || '?';
+  const statusText = (error.response && error.response.statusText) || '';
+  const detail = summarizeResponseData(error.response && error.response.data);
+  const statusPart = statusText ? `${status} ${statusText}` : String(status);
+  return `Axios ${method} ${url} → ${statusPart}${detail ? ` — ${detail}` : ''}`;
+}
+
+function formatUnexpectedError(error) {
+  if (isAxiosError(error)) {
+    return formatAxiosError(error);
+  }
+  return `${error.name || 'Error'}: ${error.message}`;
+}
+
 module.exports = function getErrorMiddleware(logger) {
   return function ErrorMiddleware(error, req, res, next) {
-    // Don't log 401 errors
-    if (!(error instanceof UnauthorizedError)) {
-      logger.error('ERROR_MIDDLEWARE');
-      logger.error(error);
-      logger.error({ path: req.route && req.route.path, user: req.user && req.user.id });
+    const context = formatRequestContext(req);
+
+    if (error instanceof UnauthorizedError) {
+      // 401s are common (expired tokens) — skip logging
+    } else if (isExpectedClientError(error)) {
+      const code = error.code || (error.getStatus && error.getStatus()) || 400;
+      const message = error.errorMessage || error.message || error.constructor.name;
+      logger.warn(`${code} ${message} ${context}`);
+    } else if (error && error.type === 'StripeCardError') {
+      logger.warn(`402 ${error.message} ${context}`);
+    } else if (error && error.statusCode === 404) {
+      logger.warn(`404 Not Found ${context}`);
+    } else if (isAxiosError(error)) {
+      // Upstream HTTP failures: one compact line, never dump config/body/tokens
+      logger.error(`${formatAxiosError(error)} ${context}`);
+    } else {
+      logger.error(`${formatUnexpectedError(error)} ${context}`);
+      if (error && error.stack) {
+        logger.error(error.stack);
+      }
     }
 
-    if (
-      error instanceof ValidationError ||
-      error instanceof AlreadyExistError ||
-      error instanceof NotFoundError ||
-      error instanceof ForbiddenError ||
-      error instanceof UnauthorizedError ||
-      error instanceof BadRequestError ||
-      error instanceof TooManyRequestsError ||
-      error instanceof PaymentRequiredError
-    ) {
+    if (isExpectedClientError(error)) {
       return res.status(error.getStatus()).json(error.jsonError());
     }
 

--- a/core/middleware/errorMiddleware.js
+++ b/core/middleware/errorMiddleware.js
@@ -70,9 +70,6 @@ function formatAxiosError(error) {
 }
 
 function formatUnexpectedError(error) {
-  if (isAxiosError(error)) {
-    return formatAxiosError(error);
-  }
   return `${error.name || 'Error'}: ${error.message}`;
 }
 

--- a/core/service/axios.js
+++ b/core/service/axios.js
@@ -22,6 +22,7 @@ const requestLogger = (request) =>
 
 const errorLogger = (error) =>
   AxiosLogger.errorLogger(error, {
+    data: false,
     logger: logger.warn.bind(this),
   });
 

--- a/test/core/middleware/errorMiddleware.test.js
+++ b/test/core/middleware/errorMiddleware.test.js
@@ -1,0 +1,309 @@
+const { expect } = require('chai');
+const getErrorMiddleware = require('../../../core/middleware/errorMiddleware');
+const {
+  ValidationError,
+  AlreadyExistError,
+  NotFoundError,
+  ForbiddenError,
+  UnauthorizedError,
+  BadRequestError,
+  TooManyRequestsError,
+  PaymentRequiredError,
+} = require('../../../core/common/error');
+
+function createMockRes() {
+  const res = {
+    statusCode: null,
+    body: null,
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload) {
+      this.body = payload;
+      return this;
+    },
+  };
+  return res;
+}
+
+function createLoggerSpy() {
+  const calls = { warn: [], error: [], info: [], debug: [] };
+  return {
+    calls,
+    warn: (...args) => calls.warn.push(args),
+    error: (...args) => calls.error.push(args),
+    info: (...args) => calls.info.push(args),
+    debug: (...args) => calls.debug.push(args),
+  };
+}
+
+describe('errorMiddleware', () => {
+  it('should not log UnauthorizedError and return 401', () => {
+    const logger = createLoggerSpy();
+    const middleware = getErrorMiddleware(logger);
+    const res = createMockRes();
+    const req = { method: 'GET', route: { path: '/users/me' }, user: { id: 'user-1' } };
+
+    middleware(new UnauthorizedError(), req, res, () => {});
+
+    expect(logger.calls.warn).to.have.length(0);
+    expect(logger.calls.error).to.have.length(0);
+    expect(res.statusCode).to.equal(401);
+    expect(res.body.error_code).to.equal('UNAUTHORIZED');
+  });
+
+  it('should warn once for expected client errors without dumping a stack', () => {
+    const logger = createLoggerSpy();
+    const middleware = getErrorMiddleware(logger);
+    const res = createMockRes();
+    const req = { method: 'POST', route: { path: '/instances/access-token' } };
+
+    middleware(new ForbiddenError('Forbidden'), req, res, () => {});
+
+    expect(logger.calls.warn).to.have.length(1);
+    expect(logger.calls.warn[0][0]).to.equal('403 Forbidden POST /instances/access-token user=—');
+    expect(logger.calls.error).to.have.length(0);
+    expect(res.statusCode).to.equal(403);
+  });
+
+  it('should include the user id in the warn message when present', () => {
+    const logger = createLoggerSpy();
+    const middleware = getErrorMiddleware(logger);
+    const res = createMockRes();
+    const req = {
+      method: 'POST',
+      route: { path: '/v1/api/owntracks/:open_api_key' },
+      user: { id: 'user-42' },
+    };
+
+    middleware(new NotFoundError('NO_INSTANCE_FOUND'), req, res, () => {});
+
+    expect(logger.calls.warn[0][0]).to.equal('404 NO_INSTANCE_FOUND POST /v1/api/owntracks/:open_api_key user=user-42');
+    expect(res.statusCode).to.equal(404);
+  });
+
+  it('should handle ValidationError, AlreadyExistError, BadRequestError, TooManyRequestsError and PaymentRequiredError', () => {
+    const logger = createLoggerSpy();
+    const middleware = getErrorMiddleware(logger);
+    const req = { method: 'POST', originalUrl: '/test' };
+
+    const cases = [
+      { error: new ValidationError('user', { details: [] }), status: 422 },
+      { error: new AlreadyExistError('user', 'a@b.c'), status: 409 },
+      { error: new BadRequestError('bad'), status: 400 },
+      { error: new TooManyRequestsError('slow down'), status: 429 },
+      { error: new PaymentRequiredError('pay'), status: 402 },
+    ];
+
+    cases.forEach(({ error, status }) => {
+      const res = createMockRes();
+      middleware(error, req, res, () => {});
+      expect(res.statusCode).to.equal(status);
+      expect(logger.calls.warn.length).to.be.greaterThan(0);
+    });
+  });
+
+  it('should fall back to originalUrl or url when route path is missing', () => {
+    const logger = createLoggerSpy();
+    const middleware = getErrorMiddleware(logger);
+    const res = createMockRes();
+
+    middleware(new ForbiddenError(), { method: 'GET', originalUrl: '/from-original' }, res, () => {});
+    expect(logger.calls.warn[0][0]).to.include('/from-original');
+
+    const res2 = createMockRes();
+    middleware(new ForbiddenError(), { method: 'GET', url: '/from-url' }, res2, () => {});
+    expect(logger.calls.warn[1][0]).to.include('/from-url');
+  });
+
+  it('should warn for StripeCardError and return payment required', () => {
+    const logger = createLoggerSpy();
+    const middleware = getErrorMiddleware(logger);
+    const res = createMockRes();
+    const req = { method: 'POST', route: { path: '/accounts/subscribe' }, user: { id: 'u1' } };
+    const stripeError = { type: 'StripeCardError', message: 'card declined', statusCode: 402 };
+
+    middleware(stripeError, req, res, () => {});
+
+    expect(logger.calls.warn[0][0]).to.equal('402 card declined POST /accounts/subscribe user=u1');
+    expect(res.statusCode).to.equal(402);
+    expect(res.body.error_code).to.equal('PAYMENT_REQUIRED');
+  });
+
+  it('should warn for generic statusCode 404 errors', () => {
+    const logger = createLoggerSpy();
+    const middleware = getErrorMiddleware(logger);
+    const res = createMockRes();
+    const req = { method: 'GET', route: { path: '/missing' } };
+
+    middleware({ statusCode: 404, message: 'gone' }, req, res, () => {});
+
+    expect(logger.calls.warn[0][0]).to.equal('404 Not Found GET /missing user=—');
+    expect(res.statusCode).to.equal(404);
+  });
+
+  it('should log Axios errors as a compact single line without dumping the body', () => {
+    const logger = createLoggerSpy();
+    const middleware = getErrorMiddleware(logger);
+    const res = createMockRes();
+    const req = { method: 'POST', route: { path: '/openai/ask' } };
+    const axiosError = {
+      isAxiosError: true,
+      name: 'AxiosError',
+      message: 'Request failed with status code 504',
+      code: 'ERR_BAD_RESPONSE',
+      config: {
+        method: 'post',
+        url: 'https://open-ai.example.com',
+        data: '{"huge":"payload"}',
+        headers: { authorization: 'Bearer secret-token' },
+      },
+      response: {
+        status: 504,
+        statusText: 'Gateway Timeout',
+        data: { error: 'Scaleway request timed out' },
+      },
+    };
+
+    middleware(axiosError, req, res, () => {});
+
+    expect(logger.calls.error).to.have.length(1);
+    expect(logger.calls.error[0][0]).to.equal(
+      'Axios POST https://open-ai.example.com → 504 Gateway Timeout — Scaleway request timed out POST /openai/ask user=—',
+    );
+    expect(logger.calls.error[0][0]).to.not.include('secret-token');
+    expect(logger.calls.error[0][0]).to.not.include('huge');
+    expect(res.statusCode).to.equal(500);
+  });
+
+  it('should summarize Axios response data from string, message and nested error shapes', () => {
+    const logger = createLoggerSpy();
+    const middleware = getErrorMiddleware(logger);
+    const req = { method: 'GET', url: '/x' };
+
+    const variants = [
+      { data: 'plain text error', expected: 'plain text error' },
+      { data: { message: 'top-level message' }, expected: 'top-level message' },
+      { data: { error: { message: 'nested message' } }, expected: 'nested message' },
+      { data: { foo: 'bar' }, expected: '{"foo":"bar"}' },
+      { data: null, expected: null },
+    ];
+
+    variants.forEach(({ data, expected }, index) => {
+      const res = createMockRes();
+      middleware(
+        {
+          isAxiosError: true,
+          config: { method: 'get', url: 'https://api.example.com' },
+          response: { status: 400, statusText: 'Bad Request', data },
+        },
+        req,
+        res,
+        () => {},
+      );
+      if (expected) {
+        expect(logger.calls.error[index][0]).to.include(expected);
+      } else {
+        expect(logger.calls.error[index][0]).to.equal(
+          'Axios GET https://api.example.com → 400 Bad Request GET /x user=—',
+        );
+      }
+    });
+  });
+
+  it('should fall back when Axios config or response is missing', () => {
+    const logger = createLoggerSpy();
+    const middleware = getErrorMiddleware(logger);
+    const res = createMockRes();
+    const req = { method: 'GET', url: '/x' };
+
+    middleware({ isAxiosError: true, code: 'ECONNREFUSED', message: 'refused' }, req, res, () => {});
+
+    expect(logger.calls.error[0][0]).to.equal('Axios ? ? → ECONNREFUSED GET /x user=—');
+    expect(res.statusCode).to.equal(500);
+  });
+
+  it('should log unexpected errors with message and stack', () => {
+    const logger = createLoggerSpy();
+    const middleware = getErrorMiddleware(logger);
+    const res = createMockRes();
+    const req = { method: 'GET', route: { path: '/boom' }, user: { id: 'u9' } };
+    const error = new Error('something broke');
+
+    middleware(error, req, res, () => {});
+
+    expect(logger.calls.error[0][0]).to.equal('Error: something broke GET /boom user=u9');
+    expect(logger.calls.error[1][0]).to.equal(error.stack);
+    expect(res.statusCode).to.equal(500);
+    expect(res.body.error_code).to.equal('SERVER_ERROR');
+  });
+
+  it('should log unexpected errors without stack when missing', () => {
+    const logger = createLoggerSpy();
+    const middleware = getErrorMiddleware(logger);
+    const res = createMockRes();
+    const req = { method: 'GET', url: '/x' };
+
+    middleware({ name: 'WeirdError', message: 'no stack' }, req, res, () => {});
+
+    expect(logger.calls.error).to.have.length(1);
+    expect(logger.calls.error[0][0]).to.equal('WeirdError: no stack GET /x user=—');
+    expect(res.statusCode).to.equal(500);
+  });
+
+  it('should truncate long Axios response payloads', () => {
+    const logger = createLoggerSpy();
+    const middleware = getErrorMiddleware(logger);
+    const res = createMockRes();
+    const req = { method: 'POST', url: '/x' };
+    const long = 'x'.repeat(500);
+
+    middleware(
+      {
+        name: 'AxiosError',
+        config: { method: 'post', url: 'https://api.example.com' },
+        response: { status: 500, statusText: 'Error', data: long },
+      },
+      req,
+      res,
+      () => {},
+    );
+
+    const logged = logger.calls.error[0][0];
+    expect(logged).to.include('x'.repeat(200));
+    expect(logged).to.not.include('x'.repeat(201));
+  });
+
+  it('should ignore response data that cannot be stringified', () => {
+    const logger = createLoggerSpy();
+    const middleware = getErrorMiddleware(logger);
+    const res = createMockRes();
+    const req = { method: 'GET', url: '/x' };
+    const circular = {};
+    circular.self = circular;
+
+    middleware(
+      {
+        isAxiosError: true,
+        config: { method: 'get', url: 'https://api.example.com' },
+        response: { status: 500, statusText: 'Error', data: circular },
+      },
+      req,
+      res,
+      () => {},
+    );
+
+    expect(logger.calls.error[0][0]).to.equal('Axios GET https://api.example.com → 500 Error GET /x user=—');
+  });
+
+  it('should use placeholders when request method and path are missing', () => {
+    const logger = createLoggerSpy();
+    const middleware = getErrorMiddleware(logger);
+    const res = createMockRes();
+
+    middleware(new ForbiddenError(), {}, res, () => {});
+
+    expect(logger.calls.warn[0][0]).to.equal('403 Forbidden ? ? user=—');
+  });
+});


### PR DESCRIPTION
Expected 4xx and upstream Axios failures are logged as one-line messages instead of full stacks and request dumps, so production logs stay scannable.