### PR TITLE
Add generic external integration webhook relay route

### DIFF
--- a/core/api/openapi/openapi.controller.js
+++ b/core/api/openapi/openapi.controller.js
@@ -1,3 +1,7 @@
+// External webhook providers ban webhooks failing repeatedly, so past this
+// delay we give up on the instance answer and return an empty 200
+const EXTERNAL_INTEGRATION_WEBHOOK_TIMEOUT_MS = 10 * 1000;
+
 module.exports = function OpenApiController(openApiModel, socketModel) {
   /**
    * @api {post} /open-api-keys Create new open API key
@@ -131,6 +135,71 @@ module.exports = function OpenApiController(openApiModel, socketModel) {
   }
 
   /**
+   * @api {post} /v1/api/external-integration/:open-api-key/:selector/:webhook-key Receive external integration webhook
+   * @apiName handleExternalIntegrationWebhook
+   * @apiGroup OpenAPI
+   *
+   * @apiSuccessExample {json} Success-Response:
+   * HTTP/1.1 200 OK
+   */
+  /**
+   * @api {get} /v1/api/external-integration/:open-api-key/:selector/:webhook-key Receive external integration webhook
+   * @apiName getExternalIntegrationWebhook
+   * @apiGroup OpenAPI
+   *
+   * @apiSuccessExample {json} Success-Response:
+   * HTTP/1.1 200 OK
+   */
+  async function handleExternalIntegrationWebhook(req, res, next) {
+    // instance deleted or account without instance: answer an empty 200, never an error
+    if (!req.primaryInstance) {
+      return res.status(200).send();
+    }
+
+    // the body is parsed as a raw buffer on this route (see routes.js), it is
+    // relayed as-is to the instance with its content-type
+    const body = Buffer.isBuffer(req.body) ? req.body.toString('utf8') : '';
+
+    const message = await openApiModel.createExternalIntegrationWebhookMessage(
+      req.user,
+      req.primaryInstance,
+      req.params.selector,
+      req.params.webhook_key,
+      req.method,
+      req.query,
+      body,
+      req.headers['content-type'],
+    );
+
+    const response = await new Promise((resolve) => {
+      const timeout = setTimeout(() => resolve(null), EXTERNAL_INTEGRATION_WEBHOOK_TIMEOUT_MS);
+      socketModel
+        .sendMessageOpenApi(req.user, message)
+        .then((instanceResponse) => {
+          clearTimeout(timeout);
+          resolve(instanceResponse);
+        })
+        .catch(() => {
+          // instance not connected: same contract as the timeout, empty 200
+          clearTimeout(timeout);
+          resolve(null);
+        });
+    });
+
+    // the instance ack contains { status (200-499), content_type, body },
+    // anything else (timeout, offline instance, invalid ack) is an empty 200
+    if (!response || typeof response.status !== 'number' || response.status < 200 || response.status >= 500) {
+      return res.status(200).send();
+    }
+
+    res.status(response.status);
+    if (response.content_type) {
+      res.set('Content-Type', response.content_type);
+    }
+    return res.send(response.body === undefined || response.body === null ? '' : response.body);
+  }
+
+  /**
    * @api {post} /v1/api/mcp/:open-api-key Send mcp webhook
    * @apiName sendMcpWebhook
    * @apiGroup OpenAPI
@@ -232,6 +301,7 @@ module.exports = function OpenApiController(openApiModel, socketModel) {
     createMessage,
     createDeviceState,
     handleNetatmoWebhook,
+    handleExternalIntegrationWebhook,
     handleMcpWebhook,
   };
 };

--- a/core/api/openapi/openapi.controller.js
+++ b/core/api/openapi/openapi.controller.js
@@ -1,6 +1,6 @@
 // External webhook providers ban webhooks failing repeatedly, so past this
 // delay we give up on the instance answer and return an empty 200
-const EXTERNAL_INTEGRATION_WEBHOOK_TIMEOUT_MS = 10 * 1000;
+const DEFAULT_EXTERNAL_INTEGRATION_WEBHOOK_TIMEOUT_MS = 10 * 1000;
 
 module.exports = function OpenApiController(openApiModel, socketModel) {
   /**
@@ -171,8 +171,12 @@ module.exports = function OpenApiController(openApiModel, socketModel) {
       req.headers['content-type'],
     );
 
+    const timeoutMs =
+      parseInt(process.env.EXTERNAL_INTEGRATION_WEBHOOK_TIMEOUT_MS, 10) ||
+      DEFAULT_EXTERNAL_INTEGRATION_WEBHOOK_TIMEOUT_MS;
+
     const response = await new Promise((resolve) => {
-      const timeout = setTimeout(() => resolve(null), EXTERNAL_INTEGRATION_WEBHOOK_TIMEOUT_MS);
+      const timeout = setTimeout(() => resolve(null), timeoutMs);
       socketModel
         .sendMessageOpenApi(req.user, message)
         .then((instanceResponse) => {

--- a/core/api/openapi/openapi.model.js
+++ b/core/api/openapi/openapi.model.js
@@ -143,6 +143,36 @@ module.exports = function OpenApiModel(logger, db) {
     return message;
   }
 
+  async function createExternalIntegrationWebhookMessage(
+    user,
+    primaryInstance,
+    selector,
+    webhookKey,
+    method,
+    query,
+    body,
+    contentType,
+  ) {
+    const data = {
+      selector,
+      webhook_key: webhookKey,
+      method,
+      query,
+      body,
+      content_type: contentType,
+    };
+
+    const message = {
+      version: '1.0',
+      type: 'gladys-open-api',
+      action: 'external-integration-webhook',
+      instance_id: primaryInstance.id,
+      data,
+    };
+
+    return message;
+  }
+
   async function createMcpWebhookMessage(user, primaryInstance, method, body, headers) {
     const headersToPass = {
       ...headers,
@@ -208,6 +238,7 @@ module.exports = function OpenApiModel(logger, db) {
     createEvent,
     createOwntrackLocation,
     createNetatmoWebhookMessage,
+    createExternalIntegrationWebhookMessage,
     createMcpWebhookMessage,
     createMessage,
     createDeviceState,

--- a/core/api/routes.js
+++ b/core/api/routes.js
@@ -20,6 +20,10 @@ module.exports.load = function Routes(app, io, controllers, middlewares) {
 
   app.use(middlewares.requestExecutionTime);
 
+  // external integration webhooks: keep the raw body (any content-type) so it can
+  // be relayed as-is to the instance. Must be registered before the other parsers.
+  app.use('/v1/api/external-integration', bodyParser.raw({ type: '*/*', limit: '256kb' }));
+
   // parse application/x-www-form-urlencoded
   app.use(
     bodyParser.urlencoded({
@@ -347,6 +351,16 @@ module.exports.load = function Routes(app, io, controllers, middlewares) {
     '/v1/api/netatmo/:open_api_key',
     asyncMiddleware(middlewares.openApiKeyAuth),
     asyncMiddleware(controllers.openApiController.handleNetatmoWebhook),
+  );
+  app.post(
+    '/v1/api/external-integration/:open_api_key/:selector/:webhook_key',
+    asyncMiddleware(middlewares.openApiKeyAuthInstanceOptional),
+    asyncMiddleware(controllers.openApiController.handleExternalIntegrationWebhook),
+  );
+  app.get(
+    '/v1/api/external-integration/:open_api_key/:selector/:webhook_key',
+    asyncMiddleware(middlewares.openApiKeyAuthInstanceOptional),
+    asyncMiddleware(controllers.openApiController.handleExternalIntegrationWebhook),
   );
   app.post(
     '/v1/api/mcp/:open_api_key',

--- a/core/index.js
+++ b/core/index.js
@@ -252,6 +252,14 @@ module.exports = async (port) => {
     rateLimiter: RateLimiterMiddleware(rateLimitRedisClient),
     isSuperAdmin: IsSuperAdminMiddleware(logger),
     openApiKeyAuth: OpenApiKeyAuthMiddleware(models.openApiModel, models.userModel, models.instanceModel),
+    openApiKeyAuthInstanceOptional: OpenApiKeyAuthMiddleware(
+      models.openApiModel,
+      models.userModel,
+      models.instanceModel,
+      {
+        instanceRequired: false,
+      },
+    ),
     gladysUsage: gladysUsageMiddleware(logger, db),
     requestExecutionTime: requestExecutionTime(logger, services.analyticsService),
     adminApiAuth: AdminApiAuth(logger, legacyRedisClient),

--- a/core/middleware/openApiApiKeyAuth.js
+++ b/core/middleware/openApiApiKeyAuth.js
@@ -1,6 +1,6 @@
-const { UnauthorizedError } = require('../common/error');
+const { UnauthorizedError, NotFoundError } = require('../common/error');
 
-module.exports = function OpenApiKeyAuthMiddleware(openApiModel, userModel, instanceModel) {
+module.exports = function OpenApiKeyAuthMiddleware(openApiModel, userModel, instanceModel, options = {}) {
   return async function OpenApiKeyAuth(req, res, next) {
     // find open api key in DB
     const apiKey = await openApiModel.findOpenApiKey(req.params.open_api_key);
@@ -14,9 +14,17 @@ module.exports = function OpenApiKeyAuthMiddleware(openApiModel, userModel, inst
     req.user = user;
 
     // get instance id
-    const primaryInstance = await instanceModel.getPrimaryInstanceByAccount(user.account_id);
-
-    req.primaryInstance = primaryInstance;
+    try {
+      req.primaryInstance = await instanceModel.getPrimaryInstanceByAccount(user.account_id);
+    } catch (e) {
+      // some routes (external integration webhooks) must never fail when the
+      // instance is missing, so they get a null primaryInstance instead of a 404
+      if (options.instanceRequired === false && e instanceof NotFoundError) {
+        req.primaryInstance = null;
+      } else {
+        throw e;
+      }
+    }
 
     // update last used in DB
     await openApiModel.updateLastUsed(apiKey.id);

--- a/test/core/api/openapi/externalintegration.webhook.test.js
+++ b/test/core/api/openapi/externalintegration.webhook.test.js
@@ -82,6 +82,32 @@ describe('External integration webhook end-to-end', function Describe() {
     );
   });
 
+  it('should return an empty 200 when the instance never answers (timeout)', (done) => {
+    process.env.EXTERNAL_INTEGRATION_WEBHOOK_TIMEOUT_MS = '200';
+    const socketInstance = connectInstance(
+      (message, cb) => {
+        // the instance never acks the message
+      },
+      () => {
+        request(TEST_BACKEND_APP)
+          .post(`/v1/api/external-integration/${OPEN_API_KEY}/my-integration/events`)
+          .set('Content-Type', 'application/json')
+          .send('{}')
+          .expect(200)
+          .then((response) => {
+            expect(response.text).to.equal('');
+            delete process.env.EXTERNAL_INTEGRATION_WEBHOOK_TIMEOUT_MS;
+            socketInstance.disconnect();
+            done();
+          })
+          .catch((e) => {
+            delete process.env.EXTERNAL_INTEGRATION_WEBHOOK_TIMEOUT_MS;
+            done(e);
+          });
+      },
+    );
+  });
+
   it('should return an empty 200 when the instance ack is invalid', (done) => {
     const socketInstance = connectInstance(
       (message, cb) => {

--- a/test/core/api/openapi/externalintegration.webhook.test.js
+++ b/test/core/api/openapi/externalintegration.webhook.test.js
@@ -1,0 +1,105 @@
+const request = require('supertest');
+const { io } = require('socket.io-client');
+const { expect } = require('chai');
+const Jwt = require('../../../../core/service/jwt');
+
+const OPEN_API_KEY = '01908032961c3ec3813abaa967c3b1ae5111d84628e2f94d500a1d7e8b812bdd90b2a08e327534db';
+const INSTANCE_ID = '0bc53f3c-1e11-40d3-99a4-bd392a666eaf';
+
+describe('External integration webhook end-to-end', function Describe() {
+  this.timeout(10000);
+
+  const connectInstance = (onOpenApiMessage, onConnected) => {
+    const jwt = Jwt();
+    const jwtAccessTokenInstance = jwt.generateAccessTokenInstance({ id: INSTANCE_ID });
+    const socketInstance = io(`http://localhost:${process.env.SERVER_PORT}`);
+
+    socketInstance.on('connect', () => {
+      socketInstance.emit('instance-authentication', { access_token: jwtAccessTokenInstance }, (data) => {
+        expect(data).to.have.property('authenticated', true);
+        onConnected();
+      });
+    });
+    socketInstance.on('open-api-message', onOpenApiMessage);
+
+    return socketInstance;
+  };
+
+  it('should relay webhook to instance and return the sync response', (done) => {
+    const socketInstance = connectInstance(
+      (message, cb) => {
+        expect(message).to.have.property('type', 'gladys-open-api');
+        expect(message).to.have.property('action', 'external-integration-webhook');
+        expect(message).to.have.property('instance_id', INSTANCE_ID);
+        expect(message.data).to.deep.equal({
+          selector: 'netatmo-external',
+          webhook_key: 'events',
+          method: 'POST',
+          query: { param: 'value' },
+          body: '{"event":"test"}',
+          content_type: 'application/json',
+        });
+        cb({ status: 201, content_type: 'application/json', body: '{"received":true}' });
+      },
+      () => {
+        request(TEST_BACKEND_APP)
+          .post(`/v1/api/external-integration/${OPEN_API_KEY}/netatmo-external/events`)
+          .query({ param: 'value' })
+          .set('Content-Type', 'application/json')
+          .send('{"event":"test"}')
+          .expect('Content-Type', /json/)
+          .expect(201)
+          .then((response) => {
+            expect(response.text).to.equal('{"received":true}');
+            socketInstance.disconnect();
+            done();
+          })
+          .catch(done);
+      },
+    );
+  });
+
+  it('should return an empty 200 on a fire and forget ack', (done) => {
+    const socketInstance = connectInstance(
+      (message, cb) => {
+        expect(message).to.have.property('action', 'external-integration-webhook');
+        expect(message.data).to.have.property('webhook_key', 'motion-detected');
+        expect(message.data).to.have.property('method', 'GET');
+        expect(message.data).to.have.property('body', '');
+        cb({ status: 200 });
+      },
+      () => {
+        request(TEST_BACKEND_APP)
+          .get(`/v1/api/external-integration/${OPEN_API_KEY}/my-camera/motion-detected`)
+          .expect(200)
+          .then((response) => {
+            expect(response.text).to.equal('');
+            socketInstance.disconnect();
+            done();
+          })
+          .catch(done);
+      },
+    );
+  });
+
+  it('should return an empty 200 when the instance ack is invalid', (done) => {
+    const socketInstance = connectInstance(
+      (message, cb) => {
+        cb({ status: 500, body: 'boom' });
+      },
+      () => {
+        request(TEST_BACKEND_APP)
+          .post(`/v1/api/external-integration/${OPEN_API_KEY}/my-integration/events`)
+          .set('Content-Type', 'application/json')
+          .send('{}')
+          .expect(200)
+          .then((response) => {
+            expect(response.text).to.equal('');
+            socketInstance.disconnect();
+            done();
+          })
+          .catch(done);
+      },
+    );
+  });
+});

--- a/test/core/api/openapi/openapi.api.controller.test.js
+++ b/test/core/api/openapi/openapi.api.controller.test.js
@@ -53,6 +53,19 @@ describe('POST /v1/api/netatmo/:open-api-key', () => {
       .set('Authorization', configTest.jwtAccessTokenDashboard)
       .expect('Content-Type', /json/)
       .expect(404));
+
+  it('should return 404 when account has no primary instance', async () => {
+    await TEST_DATABASE_INSTANCE.t_instance.update(
+      { id: '0bc53f3c-1e11-40d3-99a4-bd392a666eaf' },
+      { primary_instance: false },
+    );
+    return request(TEST_BACKEND_APP)
+      .post('/v1/api/netatmo/01908032961c3ec3813abaa967c3b1ae5111d84628e2f94d500a1d7e8b812bdd90b2a08e327534db')
+      .set('Accept', 'application/json')
+      .set('Authorization', configTest.jwtAccessTokenDashboard)
+      .expect('Content-Type', /json/)
+      .expect(404);
+  });
 });
 
 describe('POST /v1/api/external-integration/:open-api-key/:selector/:webhook-key', () => {
@@ -74,6 +87,23 @@ describe('POST /v1/api/external-integration/:open-api-key/:selector/:webhook-key
       .then((response) => {
         response.text.should.equal('');
       }));
+
+  it('should return 200 empty when account has no primary instance', async () => {
+    await TEST_DATABASE_INSTANCE.t_instance.update(
+      { id: '0bc53f3c-1e11-40d3-99a4-bd392a666eaf' },
+      { primary_instance: false },
+    );
+    return request(TEST_BACKEND_APP)
+      .post(
+        '/v1/api/external-integration/01908032961c3ec3813abaa967c3b1ae5111d84628e2f94d500a1d7e8b812bdd90b2a08e327534db/my-integration/events',
+      )
+      .set('Accept', 'application/json')
+      .send({ test: true })
+      .expect(200)
+      .then((response) => {
+        response.text.should.equal('');
+      });
+  });
 });
 
 describe('GET /v1/api/external-integration/:open-api-key/:selector/:webhook-key', () => {

--- a/test/core/api/openapi/openapi.api.controller.test.js
+++ b/test/core/api/openapi/openapi.api.controller.test.js
@@ -55,6 +55,47 @@ describe('POST /v1/api/netatmo/:open-api-key', () => {
       .expect(404));
 });
 
+describe('POST /v1/api/external-integration/:open-api-key/:selector/:webhook-key', () => {
+  it('should refuse access, invalid API key', () =>
+    request(TEST_BACKEND_APP)
+      .post('/v1/api/external-integration/wrong-api-key/my-integration/events')
+      .set('Accept', 'application/json')
+      .expect('Content-Type', /json/)
+      .expect(401));
+
+  it('should return 200 empty when instance is not connected', () =>
+    request(TEST_BACKEND_APP)
+      .post(
+        '/v1/api/external-integration/01908032961c3ec3813abaa967c3b1ae5111d84628e2f94d500a1d7e8b812bdd90b2a08e327534db/my-integration/events',
+      )
+      .set('Accept', 'application/json')
+      .send({ test: true })
+      .expect(200)
+      .then((response) => {
+        response.text.should.equal('');
+      }));
+});
+
+describe('GET /v1/api/external-integration/:open-api-key/:selector/:webhook-key', () => {
+  it('should refuse access, invalid API key', () =>
+    request(TEST_BACKEND_APP)
+      .get('/v1/api/external-integration/wrong-api-key/my-integration/events')
+      .set('Accept', 'application/json')
+      .expect('Content-Type', /json/)
+      .expect(401));
+
+  it('should return 200 empty when instance is not connected', () =>
+    request(TEST_BACKEND_APP)
+      .get(
+        '/v1/api/external-integration/01908032961c3ec3813abaa967c3b1ae5111d84628e2f94d500a1d7e8b812bdd90b2a08e327534db/my-integration/events',
+      )
+      .set('Accept', 'application/json')
+      .expect(200)
+      .then((response) => {
+        response.text.should.equal('');
+      }));
+});
+
 describe('POST /v1/api/mcp/:open-api-key', () => {
   it('should refuse access, invalid API key', () =>
     request(TEST_BACKEND_APP)


### PR DESCRIPTION
## Description

Implémente le contrat gateway des webhooks pour les intégrations externes (spec B.17 du plan intégrations externes), en généralisant le comportement jusqu'ici câblé en dur pour Netatmo.

### Nouvelle route

`GET|POST /v1/api/external-integration/:open_api_key/:selector/:webhook_key`

La gateway relaie `{ selector, webhook_key, method, query, body, content_type }` à l'instance via le WebSocket Plus sous l'action unique `external-integration-webhook`, sans aucune connaissance des intégrations — la validation (selector + `webhook_key` déclaré, mode `fire_and_forget`/`sync`) appartient à l'instance.

### Comportement

- **Body brut relayé tel quel** : la route parse le corps en raw (tous content-types, limite 256 Ko) avant les parsers urlencoded/json, et relaie le corps + son `content-type` sans interprétation.
- **Timeout dur de 10 s** sur la réponse de l'instance.
- **`200` corps vide, toujours**, en cas de timeout, d'instance hors-ligne, d'instance supprimée ou d'ack invalide — le fix durable de la leçon Netatmo (5 échecs consécutifs = webhook banni par le tiers). Seule une clé Open API invalide répond `401`.
- **Réponse sync relayée telle quelle** : l'ack de l'instance `{ status: 200–499, content_type, body }` est renvoyé au tiers (status, content-type et body) ; un ack `{ status: 200 }` (fire and forget) donne un `200` vide.

### Changements

- `core/api/routes.js` : nouvelle route GET/POST + parser raw dédié (256 Ko) enregistré avant les autres parsers.
- `core/api/openapi/openapi.controller.js` : `handleExternalIntegrationWebhook` (timeout 10 s, repli `200` vide, relais de la réponse sync).
- `core/api/openapi/openapi.model.js` : `createExternalIntegrationWebhookMessage`.
- `core/middleware/openApiApiKeyAuth.js` : option `instanceRequired: false` — la route webhook reçoit `primaryInstance = null` au lieu d'un `404` quand le compte n'a plus d'instance primaire.
- La route Netatmo existante est conservée telle quelle (rétro-compatibilité).

### Tests

- Tests HTTP : clé invalide → `401`, instance non connectée → `200` vide (GET et POST).
- Tests end-to-end avec une instance connectée en WebSocket : relais du message complet (query, body brut, content-type) et retour de la réponse sync, ack fire-and-forget → `200` vide, ack invalide (status 500) → `200` vide.
- Suites `openapi` + `socket` : 39 passing. Les échecs restants du run complet local (backup/caméra/Google) nécessitent des secrets AWS/Google injectés par la CI et sont préexistants.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017UVJmyW9cVtBa3hZYZ8KVL

---
_Generated by [Claude Code](https://claude.ai/code/session_017UVJmyW9cVtBa3hZYZ8KVL)_