### PR TITLE
feat(billing): remind yearly subscribers before their renewal

### DIFF
--- a/core/api/account/account.model.js
+++ b/core/api/account/account.model.js
@@ -19,6 +19,7 @@ const {
   getRenewalDate,
   hasRecentPaymentFailedEmail,
   hasRecentRenewalReminderEmail,
+  isSubscriptionTrialing,
   isWithinRenewalNoticeWindow,
 } = require('../../common/billing-email-scope');
 const { normalizeLanguage } = require('../../common/language');
@@ -714,12 +715,25 @@ module.exports = function AccountModel(
         // only exist on a yearly subscription — a monthly one is cancellable at
         // any time in one click, and a reminder every month would be spam.
         let interval = getInvoiceInterval(invoice);
-        if (!interval && invoice.subscription) {
-          const subscription = await stripeService.getSubscription(invoice.subscription);
-          interval = subscription?.items?.data?.[0]?.price?.recurring?.interval || null;
+        const subscriptionId = invoice.subscription || account.stripe_subscription_id;
+        let subscription = null;
+
+        // Fetched as soon as this could be a yearly renewal: the subscription
+        // carries both the interval, when the invoice does not, and the trial
+        // state, which `account.status` cannot be trusted for (a checkout
+        // account is inserted as `active` even while Stripe still has it
+        // trialing).
+        if ((!interval || interval === 'year') && subscriptionId) {
+          subscription = await stripeService.getSubscription(subscriptionId);
+          interval = interval || subscription?.items?.data?.[0]?.price?.recurring?.interval || null;
         }
 
         if (interval !== 'year') {
+          break;
+        }
+
+        // The first charge at the end of a trial is not a tacit renewal.
+        if (isSubscriptionTrialing(subscription)) {
           break;
         }
 

--- a/core/api/account/account.model.js
+++ b/core/api/account/account.model.js
@@ -11,10 +11,13 @@ const {
 
 const {
   buildPaymentFailedScope,
+  buildSubscriptionWillRenewScope,
   buildTrialWillEndScope,
   buildWelcomeScope,
   extractFirstname,
+  getInvoiceInterval,
   hasRecentPaymentFailedEmail,
+  hasRecentRenewalReminderEmail,
 } = require('../../common/billing-email-scope');
 const { normalizeLanguage } = require('../../common/language');
 const { normalizeEmail } = require('../../common/normalize-email');
@@ -697,6 +700,52 @@ module.exports = function AccountModel(
           email,
           language,
         });
+        break;
+      }
+
+      case 'invoice.upcoming': {
+        const invoice = event.data.object;
+
+        // Article L. 215-1 of the French consumer code: for a subscription with
+        // tacit renewal, the customer must be told they can decide not to renew,
+        // between three months and one month before the term. That window can
+        // only exist on a yearly subscription — a monthly one is cancellable at
+        // any time in one click, and a reminder every month would be spam.
+        let interval = getInvoiceInterval(invoice);
+        if (!interval && invoice.subscription) {
+          const subscription = await stripeService.getSubscription(invoice.subscription);
+          interval = subscription?.items?.data?.[0]?.price?.recurring?.interval || null;
+        }
+
+        if (interval !== 'year') {
+          break;
+        }
+
+        // Stripe retries webhooks, and the reminder must go out once per renewal.
+        const shouldSendRenewalReminderEmail = !(await hasRecentRenewalReminderEmail(db, account.id));
+
+        await db.t_account_payment_activity.insert({
+          stripe_event: event.type,
+          account_id: account.id,
+          hosted_invoice_url: invoice.hosted_invoice_url,
+          invoice_pdf: invoice.invoice_pdf,
+          amount_paid: invoice.amount_paid,
+          closed: invoice.closed,
+          currency: invoice.currency,
+          params: event,
+        });
+
+        if (language && email && shouldSendRenewalReminderEmail) {
+          const customer = await stripeService.getCustomer(invoice.customer);
+          const subscriptionWillRenewScope = buildSubscriptionWillRenewScope({
+            invoice,
+            customer,
+            language,
+            account,
+          });
+          await mailService.send({ email, language }, 'subscription_will_renew', subscriptionWillRenewScope);
+        }
+
         break;
       }
 

--- a/core/api/account/account.model.js
+++ b/core/api/account/account.model.js
@@ -16,8 +16,10 @@ const {
   buildWelcomeScope,
   extractFirstname,
   getInvoiceInterval,
+  getRenewalDate,
   hasRecentPaymentFailedEmail,
   hasRecentRenewalReminderEmail,
+  isWithinRenewalNoticeWindow,
 } = require('../../common/billing-email-scope');
 const { normalizeLanguage } = require('../../common/language');
 const { normalizeEmail } = require('../../common/normalize-email');
@@ -707,7 +709,7 @@ module.exports = function AccountModel(
         const invoice = event.data.object;
 
         // Article L. 215-1 of the French consumer code: for a subscription with
-        // tacit renewal, the customer must be told they can decide not to renew,
+        // tacit renewal, the customer must be told they may decide not to renew,
         // between three months and one month before the term. That window can
         // only exist on a yearly subscription — a monthly one is cancellable at
         // any time in one click, and a reminder every month would be spam.
@@ -721,21 +723,21 @@ module.exports = function AccountModel(
           break;
         }
 
+        // An event arriving too close to the renewal cannot be the legal notice.
+        // Better to send nothing and leave the gap visible than to record a
+        // reminder that does not satisfy L. 215-1.
+        if (!isWithinRenewalNoticeWindow(getRenewalDate(invoice))) {
+          logger.warn(
+            `Stripe Webhook: invoice.upcoming received outside the renewal notice window for account ${account.id}. ` +
+              `Raise "Upcoming renewal events" in the Stripe dashboard to at least 30 days.`,
+          );
+          break;
+        }
+
         // Stripe retries webhooks, and the reminder must go out once per renewal.
-        const shouldSendRenewalReminderEmail = !(await hasRecentRenewalReminderEmail(db, account.id));
+        const alreadyReminded = await hasRecentRenewalReminderEmail(db, account.id);
 
-        await db.t_account_payment_activity.insert({
-          stripe_event: event.type,
-          account_id: account.id,
-          hosted_invoice_url: invoice.hosted_invoice_url,
-          invoice_pdf: invoice.invoice_pdf,
-          amount_paid: invoice.amount_paid,
-          closed: invoice.closed,
-          currency: invoice.currency,
-          params: event,
-        });
-
-        if (language && email && shouldSendRenewalReminderEmail) {
+        if (language && email && !alreadyReminded) {
           const customer = await stripeService.getCustomer(invoice.customer);
           const subscriptionWillRenewScope = buildSubscriptionWillRenewScope({
             invoice,
@@ -744,6 +746,21 @@ module.exports = function AccountModel(
             account,
           });
           await mailService.send({ email, language }, 'subscription_will_renew', subscriptionWillRenewScope);
+
+          // Written only once the email actually went out: this row is what
+          // proves the notice was given, and what suppresses the next retry. A
+          // failed send throws before this point, so Stripe retries and the
+          // reminder is sent again rather than being silently skipped.
+          await db.t_account_payment_activity.insert({
+            stripe_event: event.type,
+            account_id: account.id,
+            hosted_invoice_url: invoice.hosted_invoice_url,
+            invoice_pdf: invoice.invoice_pdf,
+            amount_paid: invoice.amount_paid,
+            closed: invoice.closed,
+            currency: invoice.currency,
+            params: event,
+          });
         }
 
         break;

--- a/core/common/billing-email-scope.js
+++ b/core/common/billing-email-scope.js
@@ -188,6 +188,54 @@ function buildPaymentFailedScope({ invoice, customer, language, account }) {
   };
 }
 
+function getRenewalDate(invoice) {
+  return invoice.next_payment_attempt || invoice.period_end || invoice.lines?.data?.[0]?.period?.end;
+}
+
+/**
+ * Billing interval of an upcoming invoice, when the invoice carries it. Returns
+ * null when it can't be read, so the caller can fall back to the subscription.
+ */
+function getInvoiceInterval(invoice) {
+  return invoice.lines?.data?.[0]?.price?.recurring?.interval || null;
+}
+
+function buildSubscriptionWillRenewScope({ invoice, customer, language, account }) {
+  const normalizedLanguage = normalizeLanguage(language);
+  const planName = account.plan === 'lite' ? 'Lite' : 'Plus';
+
+  return {
+    firstname: extractFirstname(customer?.name),
+    renewalDate: formatBillingDate(getRenewalDate(invoice), normalizedLanguage),
+    amount: formatInvoiceAmount(invoice.amount_due, invoice.currency, normalizedLanguage),
+    planName,
+    planBenefits: getPlanBenefits(planName, normalizedLanguage),
+    manageSubscriptionLink: buildUpdateCardLink(account),
+    loginUrl: process.env.GLADYS_PLUS_FRONTEND_URL,
+  };
+}
+
+/**
+ * Article L. 215-1 of the French consumer code requires the reminder to be sent
+ * once per renewal, and Stripe retries webhooks: a reminder already recorded for
+ * this account in the last 90 days is a duplicate, since only yearly
+ * subscriptions get one.
+ */
+async function hasRecentRenewalReminderEmail(db, accountId) {
+  const ninetyDaysAgo = new Date(Date.now() - 90 * ONE_DAY_IN_MS);
+  const recent = await db.query(
+    `SELECT id FROM t_account_payment_activity
+     WHERE account_id = $1
+       AND stripe_event = 'invoice.upcoming'
+       AND created_at > $2
+       AND is_deleted = false
+     LIMIT 1`,
+    [accountId, ninetyDaysAgo],
+  );
+
+  return recent.length > 0;
+}
+
 async function hasRecentPaymentFailedEmail(db, accountId) {
   const twentyFourHoursAgo = new Date(Date.now() - ONE_DAY_IN_MS);
   const recent = await db.query(
@@ -205,6 +253,7 @@ async function hasRecentPaymentFailedEmail(db, accountId) {
 
 module.exports = {
   buildPaymentFailedScope,
+  buildSubscriptionWillRenewScope,
   buildTrialWillEndScope,
   buildWelcomeScope,
   extractFirstname,
@@ -214,6 +263,9 @@ module.exports = {
   getPlanBenefits,
   getPlanName,
   getPlanProductName,
+  getInvoiceInterval,
+  getRenewalDate,
   getWelcomeSteps,
   hasRecentPaymentFailedEmail,
+  hasRecentRenewalReminderEmail,
 };

--- a/core/common/billing-email-scope.js
+++ b/core/common/billing-email-scope.js
@@ -213,6 +213,20 @@ function getRenewalDate(invoice) {
 const MINIMUM_NOTICE_DAYS = 28;
 const MAXIMUM_NOTICE_DAYS = 92;
 
+/**
+ * Stripe also fires `invoice.upcoming` before the FIRST charge of a subscription
+ * still in trial. That invoice is not a tacit renewal: telling the customer
+ * they may refuse a renewal, at the very start of their trial, is both wrong
+ * and already covered by the `trial_will_end` email.
+ */
+function isSubscriptionTrialing(subscription, now = Date.now()) {
+  if (!subscription) {
+    return false;
+  }
+
+  return subscription.status === 'trialing' || !!(subscription.trial_end && subscription.trial_end * 1000 > now);
+}
+
 function isWithinRenewalNoticeWindow(renewalTimestamp, now = Date.now()) {
   if (!renewalTimestamp) {
     return false;
@@ -296,6 +310,7 @@ module.exports = {
   getPlanProductName,
   getInvoiceInterval,
   getRenewalDate,
+  isSubscriptionTrialing,
   isWithinRenewalNoticeWindow,
   getWelcomeSteps,
   hasRecentPaymentFailedEmail,

--- a/core/common/billing-email-scope.js
+++ b/core/common/billing-email-scope.js
@@ -188,8 +188,39 @@ function buildPaymentFailedScope({ invoice, customer, language, account }) {
   };
 }
 
+/**
+ * Date the subscription renews, on an upcoming invoice. `next_payment_attempt`
+ * is the charge date when Stripe collects automatically. The fallbacks are the
+ * START of the period being invoiced — its end is one term later, a year off
+ * for a yearly subscription.
+ */
 function getRenewalDate(invoice) {
-  return invoice.next_payment_attempt || invoice.period_end || invoice.lines?.data?.[0]?.period?.end;
+  return invoice.next_payment_attempt || invoice.period_start || invoice.lines?.data?.[0]?.period?.start;
+}
+
+/**
+ * Article L. 215-1 of the French consumer code wants the notice sent between
+ * three months and one month before the term. Stripe fires `invoice.upcoming`
+ * as many days ahead as the "Upcoming renewal events" Dashboard setting says,
+ * so an event can perfectly well arrive a few days before the renewal — early
+ * enough to be a courtesy heads-up, too late to be the legal notice. Sending
+ * then, and recording it as if the notice had been given, is worse than not
+ * sending: it hides the gap.
+ *
+ * The lower bound keeps two days of slack, because the event fires on a daily
+ * schedule rather than to the second.
+ */
+const MINIMUM_NOTICE_DAYS = 28;
+const MAXIMUM_NOTICE_DAYS = 92;
+
+function isWithinRenewalNoticeWindow(renewalTimestamp, now = Date.now()) {
+  if (!renewalTimestamp) {
+    return false;
+  }
+
+  const daysUntilRenewal = (renewalTimestamp * 1000 - now) / ONE_DAY_IN_MS;
+
+  return daysUntilRenewal >= MINIMUM_NOTICE_DAYS && daysUntilRenewal <= MAXIMUM_NOTICE_DAYS;
 }
 
 /**
@@ -265,6 +296,7 @@ module.exports = {
   getPlanProductName,
   getInvoiceInterval,
   getRenewalDate,
+  isWithinRenewalNoticeWindow,
   getWelcomeSteps,
   hasRecentPaymentFailedEmail,
   hasRecentRenewalReminderEmail,

--- a/core/common/dev-email-server.js
+++ b/core/common/dev-email-server.js
@@ -33,6 +33,8 @@ app.get('/:template_name/:language', (req, res) => {
         'Streaming caméra à distance',
         'Intégrations avancées (IA, Enedis, MCP)',
       ],
+      renewalDate: '25 juin 2026',
+      manageSubscriptionLink: 'http://gladysassistant.com',
       attemptDate: '22 juin 2026',
       nextRetryDate: '25 juin 2026',
       hostedInvoiceUrl: 'https://invoice.stripe.com/example',

--- a/core/common/email-template/en/subscription_will_renew.ejs
+++ b/core/common/email-template/en/subscription_will_renew.ejs
@@ -1,0 +1,74 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;">
+<head>
+  <meta name="viewport" content="width=device-width" />
+  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+  <title>Your Gladys Plus subscription renews soon</title>
+</head>
+<body style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 14px; -webkit-font-smoothing: antialiased; -webkit-text-size-adjust: none; width: 100% !important; height: 100%; line-height: 1.6em; background-color: #f6f6f6; margin: 0;" bgcolor="#f6f6f6">
+  <table width="100%" cellpadding="0" cellspacing="0" style="background-color: #f6f6f6;" bgcolor="#f6f6f6">
+    <tr>
+      <td></td>
+      <td width="600" style="display: block !important; max-width: 600px !important; clear: both !important; margin: 0 auto;">
+        <div style="max-width: 600px; display: block; margin: 0 auto; padding: 20px;">
+          <table width="100%" cellpadding="0" cellspacing="0" style="border-radius: 3px; background-color: #fff; border: 1px solid #e9e9e9;" bgcolor="#fff">
+            <tr>
+              <td style="padding: 20px;" valign="top">
+                <h1 style="font-family: 'Helvetica Neue', Helvetica, Arial, 'Lucida Grande', sans-serif; font-size: 32px; line-height: 1.2; color: #000; font-weight: 200; margin: 10px 0 20px; padding: 0;">
+                  Your subscription renews on <%= renewalDate %>
+                </h1>
+
+                <p style="margin: 0 0 20px;">
+                  <% if (firstname) { %>Hi <%= firstname %>,<% } else { %>Hi,<% } %>
+                </p>
+
+                <p style="margin: 0 0 20px;">
+                  Your yearly Gladys Plus <%= planName %> subscription will renew automatically on
+                  <strong><%= renewalDate %></strong><% if (amount) { %>, for <strong><%= amount %></strong><% } %>.
+                  There is nothing to do to keep it running, and you keep:
+                </p>
+
+                <ul style="margin: 0 0 20px; padding-left: 20px;">
+                  <% planBenefits.forEach(function(benefit) { %>
+                    <li style="margin-bottom: 8px;"><%= benefit %></li>
+                  <% }); %>
+                </ul>
+
+                <p style="margin: 0 0 20px;">
+                  <strong>If you would rather not renew</strong>, you can cancel at any time before that date, in one
+                  click from your billing area. Your subscription will stay active until <%= renewalDate %> and will
+                  not be renewed.
+                </p>
+
+                <p style="margin: 0 0 24px;">
+                  <a href="<%= manageSubscriptionLink %>" style="font-size: 14px; color: #fff; text-decoration: none; line-height: 2em; font-weight: bold; text-align: center; cursor: pointer; display: inline-block; border-radius: 5px; background-color: #348eda; border-color: #348eda; border-style: solid; border-width: 10px 20px;">
+                    Manage my subscription
+                  </a>
+                </p>
+
+                <p style="margin: 0 0 20px;">
+                  Or open this link directly:
+                  <a href="<%= manageSubscriptionLink %>"><%= manageSubscriptionLink %></a>
+                </p>
+
+                <p style="margin: 0 0 20px;">
+                  It is also the right place to update your card if it has expired, and to download your invoices.
+                </p>
+
+                <p style="margin: 0 0 20px;">
+                  Any question? Just reply to this email.
+                </p>
+
+                <p style="margin: 0 0 20px;">
+                  Pierre-Gilles Leymarie, founder of Gladys Assistant
+                </p>
+              </td>
+            </tr>
+          </table>
+        </div>
+      </td>
+      <td></td>
+    </tr>
+  </table>
+</body>
+</html>

--- a/core/common/email-template/fr/subscription_will_renew.ejs
+++ b/core/common/email-template/fr/subscription_will_renew.ejs
@@ -1,0 +1,75 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;">
+<head>
+  <meta name="viewport" content="width=device-width" />
+  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+  <title>Ton abonnement Gladys Plus se renouvelle bientôt</title>
+</head>
+<body style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 14px; -webkit-font-smoothing: antialiased; -webkit-text-size-adjust: none; width: 100% !important; height: 100%; line-height: 1.6em; background-color: #f6f6f6; margin: 0;" bgcolor="#f6f6f6">
+  <table width="100%" cellpadding="0" cellspacing="0" style="background-color: #f6f6f6;" bgcolor="#f6f6f6">
+    <tr>
+      <td></td>
+      <td width="600" style="display: block !important; max-width: 600px !important; clear: both !important; margin: 0 auto;">
+        <div style="max-width: 600px; display: block; margin: 0 auto; padding: 20px;">
+          <table width="100%" cellpadding="0" cellspacing="0" style="border-radius: 3px; background-color: #fff; border: 1px solid #e9e9e9;" bgcolor="#fff">
+            <tr>
+              <td style="padding: 20px;" valign="top">
+                <h1 style="font-family: 'Helvetica Neue', Helvetica, Arial, 'Lucida Grande', sans-serif; font-size: 32px; line-height: 1.2; color: #000; font-weight: 200; margin: 10px 0 20px; padding: 0;">
+                  Ton abonnement se renouvelle le <%= renewalDate %>
+                </h1>
+
+                <p style="margin: 0 0 20px;">
+                  <% if (firstname) { %>Salut <%= firstname %>,<% } else { %>Salut,<% } %>
+                </p>
+
+                <p style="margin: 0 0 20px;">
+                  Ton abonnement annuel Gladys Plus <%= planName %> sera reconduit automatiquement le
+                  <strong><%= renewalDate %></strong><% if (amount) { %>, pour un montant de <strong><%= amount %></strong><% } %>.
+                  Tu n'as rien à faire pour continuer, et tu gardes :
+                </p>
+
+                <ul style="margin: 0 0 20px; padding-left: 20px;">
+                  <% planBenefits.forEach(function(benefit) { %>
+                    <li style="margin-bottom: 8px;"><%= benefit %></li>
+                  <% }); %>
+                </ul>
+
+                <p style="margin: 0 0 20px;">
+                  <strong>Si tu ne souhaites pas reconduire ton abonnement</strong>, tu peux y mettre fin à tout moment
+                  avant cette date, en un clic depuis ton espace de gestion. Ton abonnement restera actif jusqu'au
+                  <%= renewalDate %> et ne sera pas renouvelé.
+                </p>
+
+                <p style="margin: 0 0 24px;">
+                  <a href="<%= manageSubscriptionLink %>" style="font-size: 14px; color: #fff; text-decoration: none; line-height: 2em; font-weight: bold; text-align: center; cursor: pointer; display: inline-block; border-radius: 5px; background-color: #348eda; border-color: #348eda; border-style: solid; border-width: 10px 20px;">
+                    Gérer mon abonnement
+                  </a>
+                </p>
+
+                <p style="margin: 0 0 20px;">
+                  Ou ouvre ce lien directement :
+                  <a href="<%= manageSubscriptionLink %>"><%= manageSubscriptionLink %></a>
+                </p>
+
+                <p style="margin: 0 0 20px;">
+                  C'est aussi le bon endroit pour mettre à jour ta carte bancaire si elle a expiré, et pour récupérer
+                  tes factures.
+                </p>
+
+                <p style="margin: 0 0 20px;">
+                  Une question ? Réponds simplement à cet email.
+                </p>
+
+                <p style="margin: 0 0 20px;">
+                  Pierre-Gilles Leymarie, fondateur de Gladys Assistant
+                </p>
+              </td>
+            </tr>
+          </table>
+        </div>
+      </td>
+      <td></td>
+    </tr>
+  </table>
+</body>
+</html>

--- a/core/common/email.js
+++ b/core/common/email.js
@@ -62,6 +62,16 @@ module.exports = {
       ejs: ejs.compile(fs.readFileSync(`${__dirname}/email-template/fr/welcome_back.ejs`, 'utf8')),
     },
   },
+  subscription_will_renew: {
+    en: {
+      subject: 'Your Gladys Plus subscription renews soon',
+      ejs: ejs.compile(fs.readFileSync(`${__dirname}/email-template/en/subscription_will_renew.ejs`, 'utf8')),
+    },
+    fr: {
+      subject: 'Ton abonnement Gladys Plus se renouvelle bientôt',
+      ejs: ejs.compile(fs.readFileSync(`${__dirname}/email-template/fr/subscription_will_renew.ejs`, 'utf8')),
+    },
+  },
   trial_will_end: {
     en: {
       subject: 'Your Gladys Plus trial is ending soon, keep your backups running',

--- a/test/core/api/account/account.stripeWebhook.controller.test.js
+++ b/test/core/api/account/account.stripeWebhook.controller.test.js
@@ -1009,7 +1009,22 @@ describe('stripeWebhook', () => {
       });
     });
 
-    function buildUpcomingInvoiceEvent({ id, interval }) {
+    function buildUpcomingInvoiceEvent({ id, interval, daysUntilRenewal = 45, subscription = 'sub' }) {
+      const lines = interval
+        ? {
+            data: [
+              {
+                price: {
+                  unit_amount: 9999,
+                  currency: 'eur',
+                  recurring: { interval },
+                  product: 'plus-plan-id',
+                },
+              },
+            ],
+          }
+        : { data: [{}] };
+
       return {
         id,
         object: 'event',
@@ -1017,50 +1032,84 @@ describe('stripeWebhook', () => {
         data: {
           object: {
             customer: 'cus',
-            subscription: 'sub',
+            subscription,
             amount_due: 9999,
             amount_paid: 0,
             currency: 'eur',
             closed: false,
-            next_payment_attempt: Math.floor(Date.now() / 1000) + 45 * 24 * 60 * 60,
-            lines: {
-              data: [
-                {
-                  price: {
-                    unit_amount: 9999,
-                    currency: 'eur',
-                    recurring: { interval },
-                    product: 'plus-plan-id',
-                  },
-                },
-              ],
-            },
+            next_payment_attempt: Math.floor(Date.now() / 1000) + daysUntilRenewal * 24 * 60 * 60,
+            lines,
           },
         },
       };
     }
 
-    it('should ignore invoice.upcoming for a monthly subscription', async () => {
-      await sendStripeWebhook(buildUpcomingInvoiceEvent({ id: 'evt_upcoming_monthly', interval: 'month' }));
-
-      const activities = await TEST_DATABASE_INSTANCE.t_account_payment_activity.find({
+    function findRenewalReminders() {
+      return TEST_DATABASE_INSTANCE.t_account_payment_activity.find({
         account_id: accountId,
         stripe_event: 'invoice.upcoming',
       });
+    }
 
-      expect(activities).to.have.lengthOf(0);
-    });
-
-    it('should record a renewal reminder on invoice.upcoming for a yearly subscription', async () => {
-      await sendStripeWebhook(buildUpcomingInvoiceEvent({ id: 'evt_upcoming_yearly', interval: 'year' }));
-
-      const activities = await TEST_DATABASE_INSTANCE.t_account_payment_activity.find({
-        account_id: accountId,
-        stripe_event: 'invoice.upcoming',
+    describe('renewal reminder', () => {
+      // Other cases in this file also write renewal reminders, and the handler
+      // deduplicates on the last 90 days: each case starts from a clean slate.
+      beforeEach(async () => {
+        await TEST_DATABASE_INSTANCE.t_account_payment_activity.destroy({
+          account_id: accountId,
+          stripe_event: 'invoice.upcoming',
+        });
       });
 
-      expect(activities).to.have.lengthOf(1);
-      expect(activities[0]).to.have.property('currency', 'eur');
+      it('should ignore invoice.upcoming for a monthly subscription', async () => {
+        await sendStripeWebhook(buildUpcomingInvoiceEvent({ id: 'evt_upcoming_monthly', interval: 'month' }));
+
+        expect(await findRenewalReminders()).to.have.lengthOf(0);
+      });
+
+      it('should send a renewal reminder for a yearly subscription', async () => {
+        await sendStripeWebhook(buildUpcomingInvoiceEvent({ id: 'evt_upcoming_yearly', interval: 'year' }));
+
+        // The row is written only after mailService.send resolved, so its
+        // presence is what proves the reminder actually went out.
+        const reminders = await findRenewalReminders();
+        expect(reminders).to.have.lengthOf(1);
+        expect(reminders[0]).to.have.property('currency', 'eur');
+      });
+
+      it('should not send a second reminder when Stripe retries the webhook', async () => {
+        const event = buildUpcomingInvoiceEvent({ id: 'evt_upcoming_retry', interval: 'year' });
+
+        await sendStripeWebhook(event);
+        await sendStripeWebhook(event);
+
+        expect(await findRenewalReminders()).to.have.lengthOf(1);
+      });
+
+      it('should not send a reminder when the renewal is too close to be the legal notice', async () => {
+        await sendStripeWebhook(
+          buildUpcomingInvoiceEvent({ id: 'evt_upcoming_too_close', interval: 'year', daysUntilRenewal: 5 }),
+        );
+
+        expect(await findRenewalReminders()).to.have.lengthOf(0);
+      });
+
+      it('should read the interval from the subscription when the invoice does not carry it', async () => {
+        nock('https://api.stripe.com:443', { encodedQueryParams: true })
+          .get('/v1/subscriptions/sub_yearly')
+          .reply(200, {
+            id: 'sub_yearly',
+            items: {
+              data: [{ price: { recurring: { interval: 'year' }, product: 'plus-plan-id' } }],
+            },
+          });
+
+        await sendStripeWebhook(
+          buildUpcomingInvoiceEvent({ id: 'evt_upcoming_no_interval', interval: null, subscription: 'sub_yearly' }),
+        );
+
+        expect(await findRenewalReminders()).to.have.lengthOf(1);
+      });
     });
 
     it('should record payment_failed activity and deduplicate emails within 24 hours', async () => {

--- a/test/core/api/account/account.stripeWebhook.controller.test.js
+++ b/test/core/api/account/account.stripeWebhook.controller.test.js
@@ -1094,6 +1094,25 @@ describe('stripeWebhook', () => {
         expect(await findRenewalReminders()).to.have.lengthOf(0);
       });
 
+      it('should not send a renewal reminder while the subscription is still in trial', async () => {
+        nock('https://api.stripe.com:443', { encodedQueryParams: true })
+          .get('/v1/subscriptions/sub_trialing')
+          .reply(200, {
+            id: 'sub_trialing',
+            status: 'trialing',
+            trial_end: Math.floor(Date.now() / 1000) + 20 * 24 * 60 * 60,
+            items: {
+              data: [{ price: { recurring: { interval: 'year' }, product: 'plus-plan-id' } }],
+            },
+          });
+
+        await sendStripeWebhook(
+          buildUpcomingInvoiceEvent({ id: 'evt_upcoming_trialing', interval: 'year', subscription: 'sub_trialing' }),
+        );
+
+        expect(await findRenewalReminders()).to.have.lengthOf(0);
+      });
+
       it('should read the interval from the subscription when the invoice does not carry it', async () => {
         nock('https://api.stripe.com:443', { encodedQueryParams: true })
           .get('/v1/subscriptions/sub_yearly')

--- a/test/core/api/account/account.stripeWebhook.controller.test.js
+++ b/test/core/api/account/account.stripeWebhook.controller.test.js
@@ -1009,6 +1009,60 @@ describe('stripeWebhook', () => {
       });
     });
 
+    function buildUpcomingInvoiceEvent({ id, interval }) {
+      return {
+        id,
+        object: 'event',
+        type: 'invoice.upcoming',
+        data: {
+          object: {
+            customer: 'cus',
+            subscription: 'sub',
+            amount_due: 9999,
+            amount_paid: 0,
+            currency: 'eur',
+            closed: false,
+            next_payment_attempt: Math.floor(Date.now() / 1000) + 45 * 24 * 60 * 60,
+            lines: {
+              data: [
+                {
+                  price: {
+                    unit_amount: 9999,
+                    currency: 'eur',
+                    recurring: { interval },
+                    product: 'plus-plan-id',
+                  },
+                },
+              ],
+            },
+          },
+        },
+      };
+    }
+
+    it('should ignore invoice.upcoming for a monthly subscription', async () => {
+      await sendStripeWebhook(buildUpcomingInvoiceEvent({ id: 'evt_upcoming_monthly', interval: 'month' }));
+
+      const activities = await TEST_DATABASE_INSTANCE.t_account_payment_activity.find({
+        account_id: accountId,
+        stripe_event: 'invoice.upcoming',
+      });
+
+      expect(activities).to.have.lengthOf(0);
+    });
+
+    it('should record a renewal reminder on invoice.upcoming for a yearly subscription', async () => {
+      await sendStripeWebhook(buildUpcomingInvoiceEvent({ id: 'evt_upcoming_yearly', interval: 'year' }));
+
+      const activities = await TEST_DATABASE_INSTANCE.t_account_payment_activity.find({
+        account_id: accountId,
+        stripe_event: 'invoice.upcoming',
+      });
+
+      expect(activities).to.have.lengthOf(1);
+      expect(activities[0]).to.have.property('currency', 'eur');
+    });
+
     it('should record payment_failed activity and deduplicate emails within 24 hours', async () => {
       const paymentFailedEvent = {
         id: 'evt_payment_failed',

--- a/test/core/common/billing-email-scope.test.js
+++ b/test/core/common/billing-email-scope.test.js
@@ -15,6 +15,7 @@ const {
   getInvoiceInterval,
   getRenewalDate,
   getWelcomeSteps,
+  isWithinRenewalNoticeWindow,
   hasRecentPaymentFailedEmail,
   hasRecentRenewalReminderEmail,
 } = require('../../../core/common/billing-email-scope');
@@ -209,10 +210,27 @@ describe('billing-email-scope', () => {
     expect(getInvoiceInterval({})).to.equal(null);
   });
 
-  it('should read the renewal date of an upcoming invoice, whichever field carries it', () => {
-    expect(getRenewalDate({ next_payment_attempt: 1700000000, period_end: 1600000000 })).to.equal(1700000000);
-    expect(getRenewalDate({ period_end: 1600000000 })).to.equal(1600000000);
-    expect(getRenewalDate({ lines: { data: [{ period: { end: 1500000000 } }] } })).to.equal(1500000000);
+  it('should read the renewal date of an upcoming invoice, never the end of the next term', () => {
+    expect(getRenewalDate({ next_payment_attempt: 1700000000, period_start: 1600000000 })).to.equal(1700000000);
+    // The period END of an upcoming invoice is one term later: on a yearly
+    // subscription it would show a date a year after the actual renewal.
+    expect(getRenewalDate({ period_start: 1600000000, period_end: 1631536000 })).to.equal(1600000000);
+    expect(getRenewalDate({ lines: { data: [{ period: { start: 1500000000, end: 1531536000 } }] } })).to.equal(
+      1500000000,
+    );
+  });
+
+  it('should only accept renewals inside the legal notice window', () => {
+    const now = Date.now();
+    const inDays = (days) => Math.floor((now + days * 24 * 60 * 60 * 1000) / 1000);
+
+    expect(isWithinRenewalNoticeWindow(inDays(45), now)).to.equal(true);
+    expect(isWithinRenewalNoticeWindow(inDays(30), now)).to.equal(true);
+    expect(isWithinRenewalNoticeWindow(inDays(90), now)).to.equal(true);
+    // Too late to be the L. 215-1 notice, or so early it is not this renewal.
+    expect(isWithinRenewalNoticeWindow(inDays(5), now)).to.equal(false);
+    expect(isWithinRenewalNoticeWindow(inDays(120), now)).to.equal(false);
+    expect(isWithinRenewalNoticeWindow(undefined, now)).to.equal(false);
   });
 
   it('should build the subscription_will_renew scope', () => {

--- a/test/core/common/billing-email-scope.test.js
+++ b/test/core/common/billing-email-scope.test.js
@@ -15,6 +15,7 @@ const {
   getInvoiceInterval,
   getRenewalDate,
   getWelcomeSteps,
+  isSubscriptionTrialing,
   isWithinRenewalNoticeWindow,
   hasRecentPaymentFailedEmail,
   hasRecentRenewalReminderEmail,
@@ -218,6 +219,17 @@ describe('billing-email-scope', () => {
     expect(getRenewalDate({ lines: { data: [{ period: { start: 1500000000, end: 1531536000 } }] } })).to.equal(
       1500000000,
     );
+  });
+
+  it('should detect a subscription still in trial', () => {
+    const now = Date.now();
+    const inDays = (days) => Math.floor((now + days * 24 * 60 * 60 * 1000) / 1000);
+
+    expect(isSubscriptionTrialing({ status: 'trialing' }, now)).to.equal(true);
+    expect(isSubscriptionTrialing({ status: 'active', trial_end: inDays(20) }, now)).to.equal(true);
+    expect(isSubscriptionTrialing({ status: 'active', trial_end: inDays(-20) }, now)).to.equal(false);
+    expect(isSubscriptionTrialing({ status: 'active' }, now)).to.equal(false);
+    expect(isSubscriptionTrialing(null, now)).to.equal(false);
   });
 
   it('should only accept renewals inside the legal notice window', () => {

--- a/test/core/common/billing-email-scope.test.js
+++ b/test/core/common/billing-email-scope.test.js
@@ -2,6 +2,7 @@ const { expect } = require('chai');
 
 const {
   buildPaymentFailedScope,
+  buildSubscriptionWillRenewScope,
   buildTrialWillEndScope,
   buildWelcomeScope,
   extractFirstname,
@@ -11,8 +12,11 @@ const {
   getPlanBenefits,
   getPlanName,
   getPlanProductName,
+  getInvoiceInterval,
+  getRenewalDate,
   getWelcomeSteps,
   hasRecentPaymentFailedEmail,
+  hasRecentRenewalReminderEmail,
 } = require('../../../core/common/billing-email-scope');
 
 describe('billing-email-scope', () => {
@@ -195,6 +199,59 @@ describe('billing-email-scope', () => {
     expect(scope.nextRetryDate).to.equal('');
     expect(scope.hostedInvoiceUrl).to.equal('');
     expect(scope.planName).to.equal('Plus');
+  });
+
+  it('should read the billing interval of an upcoming invoice', () => {
+    expect(getInvoiceInterval({ lines: { data: [{ price: { recurring: { interval: 'year' } } }] } })).to.equal('year');
+    expect(getInvoiceInterval({ lines: { data: [{ price: { recurring: { interval: 'month' } } }] } })).to.equal(
+      'month',
+    );
+    expect(getInvoiceInterval({})).to.equal(null);
+  });
+
+  it('should read the renewal date of an upcoming invoice, whichever field carries it', () => {
+    expect(getRenewalDate({ next_payment_attempt: 1700000000, period_end: 1600000000 })).to.equal(1700000000);
+    expect(getRenewalDate({ period_end: 1600000000 })).to.equal(1600000000);
+    expect(getRenewalDate({ lines: { data: [{ period: { end: 1500000000 } }] } })).to.equal(1500000000);
+  });
+
+  it('should build the subscription_will_renew scope', () => {
+    const scope = buildSubscriptionWillRenewScope({
+      invoice: {
+        next_payment_attempt: 1767225600, // 1 January 2026
+        amount_due: 9999,
+        currency: 'eur',
+      },
+      customer: { name: 'Pierre-Gilles Leymarie' },
+      language: 'fr',
+      account: { plan: 'plus', stripe_portal_key: 'portal-key' },
+    });
+
+    expect(scope.firstname).to.equal('Pierre-Gilles');
+    expect(scope.renewalDate).to.equal('1 janvier 2026');
+    expect(scope.amount).to.equal('99,99\u00a0€');
+    expect(scope.planName).to.equal('Plus');
+    expect(scope.planBenefits).to.have.length.above(0);
+    expect(scope.manageSubscriptionLink).to.equal('https://api.gladys.plus/accounts/stripe_customer_portal/portal-key');
+  });
+
+  it('should detect recent renewal reminder emails in the database', async () => {
+    const accountId = 'be2b9666-5c72-451e-98f4-efca76ffef54';
+
+    const hasRecentBefore = await hasRecentRenewalReminderEmail(TEST_DATABASE_INSTANCE, accountId);
+    expect(hasRecentBefore).to.equal(false);
+
+    await TEST_DATABASE_INSTANCE.t_account_payment_activity.insert({
+      stripe_event: 'invoice.upcoming',
+      account_id: accountId,
+      amount_paid: 0,
+      closed: false,
+      currency: 'eur',
+      params: {},
+    });
+
+    const hasRecentAfter = await hasRecentRenewalReminderEmail(TEST_DATABASE_INSTANCE, accountId);
+    expect(hasRecentAfter).to.equal(true);
   });
 
   it('should detect recent payment failed emails in the database', async () => {


### PR DESCRIPTION
## Context

Article L. 215-1 of the French consumer code requires a subscription with tacit renewal to be preceded by an email telling the customer they may decide not to renew, sent between three months and one month before the term. If it is not sent, the customer can terminate free of charge at any time from the renewal date, and the amounts paid after that date must be refunded. Nothing was sent today.

This comes out of a legal pass on the website's terms of sale ([v4-website#398](https://github.com/GladysAssistant/v4-website/pull/398)), which now states that this reminder is sent for yearly subscriptions.

## Changes

- **`invoice.upcoming` handler** in `core/api/account/account.model.js`. Stripe fires this event as many days before renewal as the **Upcoming renewal events** setting says (Dashboard → Settings → Billing → Automatic), so the timing is a Dashboard setting, not code.
- **Yearly only.** On a monthly subscription the legal window cannot exist — one month before the term is the day of subscription — the plan is cancellable at any time in one click, and a monthly reminder would be spam. The interval is read from the upcoming invoice, falling back to the subscription when the invoice does not carry it.
- **Never during a trial.** Stripe also fires the event before the first charge of a trialing subscription, which is not a tacit renewal and is already covered by `trial_will_end`. The subscription's trial state decides, not `account.status`: a checkout account is inserted as `active` even while Stripe still has it trialing.
- **Notice window guard.** An event arriving less than ~28 days or more than ~92 days before the renewal is skipped, with a warning naming the Dashboard setting to raise. Sending then, and recording it as a notice, would hide a compliance gap rather than close it.
- **`subscription_will_renew` email**, FR and EN, built like the existing `trial_will_end` one. It states the renewal date, the amount, and — the part the law is actually about — that the subscription can be ended in one click before that date, with the link to do it.
- **Sent first, recorded second.** The activity row (`stripe_event = 'invoice.upcoming'`) is written only once `mailService.send` resolved. It is therefore real proof the notice was given, and a failed send throws before it, so Stripe retries and the reminder goes out instead of being suppressed by the 90-day deduplication.
- The template is registered in the email preview server (`npm run start-email-preview`, then `/subscription_will_renew/fr`).

## Known trade-off

Two webhook deliveries overlapping within the milliseconds between the deduplication lookup and the insert could both send. The outcome is a duplicate email — no legal consequence, unlike a missed notice — and this fires about once a year per account, so no outbox or uniqueness constraint was added. If duplicates ever appear, the fix is a partial unique index on a persisted renewal key (derived like `getRenewalDate`, since `next_payment_attempt` is nullable and an upcoming invoice has no id).

## Before this has any effect

**`invoice.upcoming` must be enabled on the Stripe webhook endpoint** — it is not one of the events the endpoint listens to today. The **Upcoming renewal events** setting must be at least 30 days, and it only takes effect on the next billing period for existing subscriptions.

## Testing

- `npx eslint core test index.js` and `npx prettier --check core test index.js` are clean (the only warning is the pre-existing `no-console` in `dev-email-server.js`).
- Unit tests for the interval reading, the renewal date fallback, the trial detection, the notice window and the scope builder pass locally: `npx mocha test/core/common/billing-email-scope.test.js` → 16 passing.
- Both templates were rendered with a real scope to check the EJS compiles and interpolates.
- Webhook tests cover six paths — monthly ignored, yearly sends, retry does not resend, renewal too close is skipped, trialing subscription is skipped, interval read from the subscription when the invoice lacks it — each starting from a clean slate rather than assuming an empty table. They run in CI; the authoring environment has no Postgres or Redis.