### PR TITLE
fix(stripe): ignore charge.succeeded events without a linked account

### DIFF
--- a/core/api/account/account.model.js
+++ b/core/api/account/account.model.js
@@ -640,6 +640,15 @@ module.exports = function AccountModel(
         break;
       }
       case 'charge.succeeded': {
+        // A charge without a customer (one-shot payment, Payment Link, guest checkout)
+        // is not linked to any Gladys Plus account: nothing to update here.
+        if (!account) {
+          logger.warn(
+            `Stripe Webhook : charge.succeeded "${event.data.object.id}" received without a known account, ignoring.`,
+          );
+          break;
+        }
+
         // get currentPeriodEnd threw the API
         const currentPeriodEnd = await stripeService.getSubscriptionCurrentPeriodEnd(account.stripe_subscription_id);
 

--- a/test/core/api/account/account.stripeWebhook.controller.test.js
+++ b/test/core/api/account/account.stripeWebhook.controller.test.js
@@ -451,6 +451,40 @@ describe('stripeWebhook', () => {
     expect(accountUpdatedToPlus).to.have.property('status', 'active');
     expect(accountUpdatedToPlus).to.have.property('plan', 'plus');
   });
+  it('should ignore charge.succeeded without customer (one-shot payment, Payment Link, guest charge)', async () => {
+    // Stripe sends charge.succeeded for every charge on the Stripe account,
+    // including charges that have no customer and are not linked to any Gladys Plus account.
+    const event = {
+      id: 'evt_test_webhook_charge_without_customer',
+      object: 'event',
+      type: 'charge.succeeded',
+      data: {
+        object: {
+          id: 'ch_one_shot',
+          object: 'charge',
+          customer: null,
+          amount: 19900,
+          currency: 'eur',
+          status: 'succeeded',
+        },
+      },
+    };
+    const stringEvent = JSON.stringify(event);
+    const signatureHeader = stripe.webhooks.generateTestHeaderString({
+      payload: stringEvent,
+      secret: process.env.STRIPE_ENDPOINT_SECRET,
+    });
+    const response = await request(TEST_BACKEND_APP)
+      .post('/stripe/webhook')
+      .set('Accept', 'application/json')
+      .set('stripe-signature', signatureHeader)
+      .set('Content-type', 'application/json')
+      .send(stringEvent)
+      .expect(200);
+
+    expect(response.body).to.deep.equal({ success: true });
+  });
+
   it('should delete subscription', async () => {
     // First create subscription
     const event = {


### PR DESCRIPTION
## Problem

Sentry issue [GLADYS-GATEWAY-FY](https://gladys-assistant.sentry.io/issues/GLADYS-GATEWAY-FY): `TypeError: Cannot read properties of undefined (reading 'stripe_subscription_id')` on `POST /stripe/webhook`, 7 occurrences since 2026-08-31 (~1/day).

In `stripeEvent`, `account` is only loaded when the event carries a `customer`. A `charge.succeeded` without a customer (one-shot payment, Payment Link, guest checkout on the same Stripe account, e.g. the Gladys training sold on another platform) reached the `case 'charge.succeeded'` with `account === undefined` and crashed. Stripe received a 500 and kept retrying the webhook.

## Fix

- `core/api/account/account.model.js`: in the `charge.succeeded` case, if there is no `account`, log a warning with the charge id and `break` (webhook answers 200, Stripe stops retrying).
- `test/core/api/account/account.stripeWebhook.controller.test.js`: regression test sending a signed `charge.succeeded` event with `customer: null`. It reproduces the exact Sentry TypeError without the fix and passes with it.

## Validation

- `npm run prettier-check` and `npm run eslint` pass.
- The new test passes with the fix and fails with the original TypeError without it.

Fixes GLADYS-GATEWAY-FY

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ra7HAeD9XEdbdZYJ7ZtUTV

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ra7HAeD9XEdbdZYJ7ZtUTV)_