### PR TITLE
Sentry: stop capturing expected client errors (402, 403, 409, 422, 429…)

### DIFF
--- a/core/api/routes.js
+++ b/core/api/routes.js
@@ -2,6 +2,7 @@ const bodyParser = require('body-parser');
 const Sentry = require('@sentry/node');
 const beforeSendSentry = require('../service/beforeSendSentry');
 const asyncMiddleware = require('../middleware/asyncMiddleware');
+const { shouldReportErrorToSentry } = require('../middleware/errorMiddleware');
 const { NotFoundError } = require('../common/error');
 
 module.exports.load = function Routes(app, io, controllers, middlewares) {
@@ -573,16 +574,9 @@ module.exports.load = function Routes(app, io, controllers, middlewares) {
 
   app.use(
     Sentry.Handlers.errorHandler({
-      shouldHandleError(error) {
-        // Stop capturing 404 erros
-        if (error instanceof NotFoundError) {
-          return false;
-        }
-        if (error && error.status === 404) {
-          return false;
-        }
-        return true;
-      },
+      // Only capture unexpected errors: expected client errors (4xx raised on purpose)
+      // are already handled by the error middleware and would only pollute Sentry.
+      shouldHandleError: shouldReportErrorToSentry,
     }),
   );
 

--- a/core/middleware/errorMiddleware.js
+++ b/core/middleware/errorMiddleware.js
@@ -25,6 +25,22 @@ function isExpectedClientError(error) {
   return EXPECTED_CLIENT_ERRORS.some((ErrorClass) => error instanceof ErrorClass);
 }
 
+/**
+ * Sentry should only receive errors that are actual bugs.
+ * Expected client errors (4xx we raise on purpose: 400, 401, 402, 403, 404, 409, 422, 429)
+ * are handled by the error middleware and must not be reported.
+ */
+function shouldReportErrorToSentry(error) {
+  if (isExpectedClientError(error)) {
+    return false;
+  }
+  // generic 404 raised by third-party middlewares (e.g. express static / proxy)
+  if (error && (error.status === 404 || error.statusCode === 404)) {
+    return false;
+  }
+  return true;
+}
+
 function isAxiosError(error) {
   return Boolean(error && (error.isAxiosError === true || error.name === 'AxiosError'));
 }
@@ -73,7 +89,7 @@ function formatUnexpectedError(error) {
   return `${error.name || 'Error'}: ${error.message}`;
 }
 
-module.exports = function getErrorMiddleware(logger) {
+function getErrorMiddleware(logger) {
   return function ErrorMiddleware(error, req, res, next) {
     const context = formatRequestContext(req);
 
@@ -115,4 +131,9 @@ module.exports = function getErrorMiddleware(logger) {
     const serverError = new ServerError();
     return res.status(serverError.getStatus()).json(serverError.jsonError());
   };
-};
+}
+
+module.exports = getErrorMiddleware;
+module.exports.EXPECTED_CLIENT_ERRORS = EXPECTED_CLIENT_ERRORS;
+module.exports.isExpectedClientError = isExpectedClientError;
+module.exports.shouldReportErrorToSentry = shouldReportErrorToSentry;

--- a/test/core/middleware/errorMiddleware.test.js
+++ b/test/core/middleware/errorMiddleware.test.js
@@ -307,3 +307,46 @@ describe('errorMiddleware', () => {
     expect(logger.calls.warn[0][0]).to.equal('403 Forbidden ? ? user=—');
   });
 });
+
+describe('shouldReportErrorToSentry', () => {
+  const { shouldReportErrorToSentry, EXPECTED_CLIENT_ERRORS } = getErrorMiddleware;
+
+  it('should not report any expected client error, even with a custom message', () => {
+    EXPECTED_CLIENT_ERRORS.forEach((ErrorClass) => {
+      expect(shouldReportErrorToSentry(new ErrorClass('custom message'))).to.equal(false);
+    });
+    expect(shouldReportErrorToSentry(new ForbiddenError('You are not allowed to do that'))).to.equal(false);
+    expect(shouldReportErrorToSentry(new PaymentRequiredError('Subscription expired'))).to.equal(false);
+    expect(shouldReportErrorToSentry(new TooManyRequestsError('Slow down'))).to.equal(false);
+    expect(shouldReportErrorToSentry(new AlreadyExistError('Already there'))).to.equal(false);
+    expect(shouldReportErrorToSentry(new ValidationError('Invalid'))).to.equal(false);
+    expect(shouldReportErrorToSentry(new UnauthorizedError())).to.equal(false);
+    expect(shouldReportErrorToSentry(new BadRequestError('Bad'))).to.equal(false);
+    expect(shouldReportErrorToSentry(new NotFoundError('Nope'))).to.equal(false);
+  });
+
+  it('should not report generic 404 errors coming from third-party middlewares', () => {
+    const errorWithStatus = new Error('Not Found');
+    errorWithStatus.status = 404;
+    const errorWithStatusCode = new Error('Not Found');
+    errorWithStatusCode.statusCode = 404;
+    expect(shouldReportErrorToSentry(errorWithStatus)).to.equal(false);
+    expect(shouldReportErrorToSentry(errorWithStatusCode)).to.equal(false);
+  });
+
+  it('should report unexpected errors', () => {
+    expect(shouldReportErrorToSentry(new Error('boom'))).to.equal(true);
+    expect(shouldReportErrorToSentry(new TypeError("Cannot read property 'x' of undefined"))).to.equal(true);
+    const axiosError = new Error('Request failed with status code 500');
+    axiosError.isAxiosError = true;
+    expect(shouldReportErrorToSentry(axiosError)).to.equal(true);
+    const stripeError = new Error('Your card was declined');
+    stripeError.type = 'StripeCardError';
+    expect(shouldReportErrorToSentry(stripeError)).to.equal(true);
+  });
+
+  it('should report when error is null or undefined', () => {
+    expect(shouldReportErrorToSentry(null)).to.equal(true);
+    expect(shouldReportErrorToSentry(undefined)).to.equal(true);
+  });
+});


### PR DESCRIPTION
## Problem

Over the last month, ~95% of the ~2,800 Sentry events were expected client errors (402, 403, 409, 422, 429). The Sentry error handler in `core/api/routes.js` only filtered out 404s, so every `PaymentRequiredError`, `ForbiddenError`, `TooManyRequestsError`, `AlreadyExistError`, `ValidationError`… was reported as an "error" and drowned the real bugs.

The `ignoreErrors: ['Unauthorized', 'Forbidden', ...]` option on `Sentry.init` matches on the error *message*, so it stopped working as soon as a `ForbiddenError` was thrown with a custom message.

## Change

- `core/middleware/errorMiddleware.js`: new `shouldReportErrorToSentry(error)` helper, built on the `EXPECTED_CLIENT_ERRORS` list already used by the error middleware (it also keeps the existing generic `status`/`statusCode === 404` check). The helper, the list and `isExpectedClientError` are now exported alongside the middleware factory (the default export is unchanged).
- `core/api/routes.js`: `shouldHandleError` of `Sentry.Handlers.errorHandler` now uses `shouldReportErrorToSentry`, so filtering is done on the error *class* (`instanceof`) rather than on the message.
- `test/core/middleware/errorMiddleware.test.js`: unit tests covering every expected error class (with custom messages), generic 404s, and unexpected errors (plain `Error`, `TypeError`, Axios, Stripe) which must still be reported.

Errors that keep being reported: anything not in `EXPECTED_CLIENT_ERRORS`, i.e. `ServerError`, Axios/upstream failures, `StripeCardError`, and any unexpected exception.

## Validation

```
npx eslint core/middleware/errorMiddleware.js core/api/routes.js test/core/middleware/errorMiddleware.test.js  # OK
npx prettier --check ...                                                                                       # OK
npx mocha test/core/middleware/errorMiddleware.test.js --exit                                                  # 19 passing
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gt4nYMwSeTh89tLcwgruBM

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gt4nYMwSeTh89tLcwgruBM)_