### PR TITLE
Security: fix SQL injection, 2FA brute force, IDORs and OAuth redirect validation

### DIFF
--- a/core/api/account/account.controller.js
+++ b/core/api/account/account.controller.js
@@ -42,29 +42,6 @@ module.exports = function AccountController(accountModel, socketModel) {
   }
 
   /**
-   * @api {post} /accounts/subscribe/new New account with plan
-   * @apiName New account with plan
-   * @apiGroup Account
-   *
-   * @apiParam {String} email email
-   * @apiParam {String} language Language
-   * @apiParam {String} stripe_source_id Stripe source id
-   *
-   * @apiSuccessExample {json} Success-Response:
-   * HTTP/1.1 200 OK
-   *
-   * {
-   *   "current_period_end": 1537841579580,
-   * }
-   */
-  async function subscribeMonthlyPlanWithoutAccount(req, res, next) {
-    const account = await accountModel.subscribeMonthlyPlanWithoutAccount(req.body.email, req.body.language);
-    res.json({
-      current_period_end: account.current_period_end,
-    });
-  }
-
-  /**
    * @api {post} /stripe/webhook Stripe Webhook
    * @apiName Stripe Webhook
    * @apiGroup Stripe
@@ -243,24 +220,6 @@ module.exports = function AccountController(accountModel, socketModel) {
   }
 
   /**
-   * @api {post} /accounts/payments/sessions Create new payment session
-   * @apiName Create new payment session
-   * @apiGroup Account
-   *
-   *
-   * @apiSuccessExample {json} Success-Response:
-   * HTTP/1.1 200 OK
-   *
-   * {
-   *   "id": "unique-id"
-   * }
-   */
-  async function createPaymentSession(req, res, next) {
-    const session = await accountModel.createPaymentSession(req.body.locale || 'en');
-    res.json(session);
-  }
-
-  /**
    * @api {get} /accounts/stripe_customer_portal/:stripe_portal_key Redirect to stripe customer portal
    * @apiName Redirect to stripe customer portal
    * @apiGroup Account
@@ -279,14 +238,12 @@ module.exports = function AccountController(accountModel, socketModel) {
     getUsers,
     subscribeMonthlyPlan,
     subscribeAgainToMonthlySubscription,
-    subscribeMonthlyPlanWithoutAccount,
     updateCard,
     revokeUser,
     getCard,
     cancelMonthlySubscription,
     stripeEvent,
     getInvoices,
-    createPaymentSession,
     redirectToStripeCustomerPortal,
     upgradeFromMonthlyToYearly,
     getUserCurrentPlan,

--- a/core/api/account/account.model.js
+++ b/core/api/account/account.model.js
@@ -345,73 +345,6 @@ module.exports = function AccountModel(
     return accountUpdated;
   }
 
-  async function subscribeMonthlyPlanWithoutAccount(rawEmail, language) {
-    const email = normalizeEmail(rawEmail);
-    const role = 'admin';
-
-    // we first test if an account already exist with this email
-    const account = await db.t_account.findOne({ name: email });
-
-    // it means an account already exist with this email
-    if (account !== null) {
-      throw new AlreadyExistError();
-    }
-
-    // create the customer on stripe side
-    const customer = await stripeService.createCustomer(email);
-
-    // contact stripe to save the subscription id
-    let subscription = await stripeService.subscribeToMonthlyPlan(customer.id);
-
-    // it means stripe is disabled
-    // so we add to the account 100 years of life
-    if (subscription === null) {
-      subscription = {
-        id: 'stripe-subcription-sample',
-        current_period_end: new Date().getTime() + 100 * 365 * 24 * 60 * 60 * 1000,
-      };
-    }
-
-    const newAccount = {
-      name: email,
-      stripe_customer_id: customer.id,
-      stripe_subscription_id: subscription.id,
-      current_period_end: new Date(subscription.current_period_end * 1000),
-      status: 'trialing',
-    };
-
-    const insertedAccount = await db.t_account.insert(newAccount);
-
-    // generate email confirmation token
-    const token = (await randomBytes(64)).toString('hex');
-
-    // we hash the token in DB so it's not possible to get the token
-    // if the DB is compromised in read-only
-    // (due to SQL injection for example)
-    const tokenHash = crypto.createHash('sha256').update(token).digest('hex');
-
-    await db.t_invitation.insert({
-      email,
-      role,
-      token_hash: tokenHash,
-      account_id: insertedAccount.id,
-    });
-
-    await mailService.send(
-      { email, language },
-      'welcome',
-      buildWelcomeScope({
-        confirmationUrlGladys4: `${process.env.GLADYS_PLUS_FRONTEND_URL}/signup-gateway?token=${encodeURI(token)}`,
-        customer: { name: email },
-        subscription,
-        plan: insertedAccount.plan || 'plus',
-        language,
-      }),
-    );
-
-    return insertedAccount;
-  }
-
   async function updateCard(user, sourceId) {
     // get the account_id of the currently connected user
     const userWithAccount = await db.t_user.findOne(
@@ -914,16 +847,6 @@ module.exports = function AccountModel(
     return invoices;
   }
 
-  async function createPaymentSession(locale) {
-    if (['en', 'fr'].indexOf(locale) === -1) {
-      throw new ValidationError('Locale can only be en or fr');
-    }
-    const session = await stripeService.createSession(locale);
-    return {
-      id: session.id,
-    };
-  }
-
   async function createBillingPortalSession(stripePortalKey, geo) {
     const account = await db.t_account.findOne({
       stripe_portal_key: stripePortalKey,
@@ -947,11 +870,9 @@ module.exports = function AccountModel(
     subscribeMonthlyPlan,
     cancelMonthlySubscription,
     subscribeAgainToMonthlySubscription,
-    subscribeMonthlyPlanWithoutAccount,
     stripeEvent,
     getCard,
     getInvoices,
-    createPaymentSession,
     createBillingPortalSession,
     getAllAccounts,
     upgradeFromMonthlyToYearly,

--- a/core/api/alexa/alexa.controller.js
+++ b/core/api/alexa/alexa.controller.js
@@ -4,6 +4,7 @@
 const get = require('get-value');
 const clone = require('clone');
 const { BadRequestError } = require('../../common/error');
+const { isAllowedRedirectUri, buildRedirectUrl } = require('../../common/oauth-redirect-uri');
 
 const VALID_REDIRECT_URIS = [
   'https://pitangui.amazon.com/api/skill/link/M1CD0NOTQVDMUV',
@@ -26,12 +27,13 @@ module.exports = function AlexaController(
    * @apiGroup Alexa
    */
   async function smartHome(req, res) {
-    logger.debug(`Alexa : smartHome request`);
-    logger.debug(req.body);
-    analyticsService.sendMetric('alexa.smart-home', 1, req.user.id);
-    const user = await userModel.getMySelf({ id: req.user.id });
     const directiveNamespace = get(req.body, 'directive.header.namespace');
     const directiveName = get(req.body, 'directive.header.name');
+    // The body carries the gateway bearer token (directive.endpoint.scope.token)
+    // and the Amazon grant code, so only the directive identity is logged
+    logger.debug(`Alexa : smartHome request ${directiveNamespace}.${directiveName}`);
+    analyticsService.sendMetric('alexa.smart-home', 1, req.user.id);
+    const user = await userModel.getMySelf({ id: req.user.id });
     const primaryInstance = await instanceModel.getPrimaryInstanceByAccount(user.account_id);
 
     try {
@@ -69,9 +71,9 @@ module.exports = function AlexaController(
       const response = await socketModel.sendMessageOpenApi(user, message);
       return res.json(response);
     } catch (e) {
-      logger.error(`ALEXA_SMART_HOME_ERROR, user_id = ${user.id}`);
-      logger.error(req.body);
-      logger.error(e);
+      logger.error(
+        `ALEXA_SMART_HOME_ERROR, user_id = ${user.id}, directive = ${directiveNamespace}.${directiveName}, message = ${e.message}`,
+      );
 
       throw e;
     }
@@ -88,14 +90,11 @@ module.exports = function AlexaController(
     if (req.body.client_id !== ALEXA_OAUTH_CLIENT_ID) {
       throw new BadRequestError('client_id is not matching');
     }
-    const baseUrlFound = VALID_REDIRECT_URIS.find(
-      (redirectUriBaseUrl) => req.body.redirect_uri && req.body.redirect_uri.startsWith(redirectUriBaseUrl),
-    );
-    if (!baseUrlFound) {
+    if (!isAllowedRedirectUri(req.body.redirect_uri, VALID_REDIRECT_URIS)) {
       throw new BadRequestError('invalid redirect_uri');
     }
     const code = await alexaModel.getCode(req.user.id);
-    const redirectUrl = `${req.body.redirect_uri}?state=${req.body.state}&code=${code}`;
+    const redirectUrl = buildRedirectUrl(req.body.redirect_uri, req.body.state, code);
     res.json({
       redirectUrl,
     });

--- a/core/api/alexa/alexa.model.js
+++ b/core/api/alexa/alexa.model.js
@@ -27,12 +27,12 @@ module.exports = function AlexaModel(logger, db, redisClient, jwtService) {
       throw new ForbiddenError('INVALID_CODE');
     }
     const codeKey = `${ALEXA_OAUTH_CODE_REDIS_PREFIX}:${code}`;
-    const userId = await redisClient.get(codeKey);
+    // an authorization code is single use: GETDEL reads and removes it atomically,
+    // so two concurrent exchanges cannot both succeed
+    const userId = await redisClient.getDel(codeKey);
     if (userId === null) {
       throw new ForbiddenError('INVALID_CODE');
     }
-    // an authorization code is single use
-    await redisClient.del(codeKey);
     const user = await db.t_user.findOne(
       {
         id: userId,

--- a/core/api/alexa/alexa.model.js
+++ b/core/api/alexa/alexa.model.js
@@ -23,10 +23,16 @@ module.exports = function AlexaModel(logger, db, redisClient, jwtService) {
   const { ALEXA_OAUTH_CLIENT_ID } = process.env;
 
   async function getRefreshTokenAndAccessToken(code) {
-    const userId = await redisClient.get(`${ALEXA_OAUTH_CODE_REDIS_PREFIX}:${code}`);
+    if (typeof code !== 'string' || code.length === 0) {
+      throw new ForbiddenError('INVALID_CODE');
+    }
+    const codeKey = `${ALEXA_OAUTH_CODE_REDIS_PREFIX}:${code}`;
+    const userId = await redisClient.get(codeKey);
     if (userId === null) {
       throw new ForbiddenError('INVALID_CODE');
     }
+    // an authorization code is single use
+    await redisClient.del(codeKey);
     const user = await db.t_user.findOne(
       {
         id: userId,

--- a/core/api/backup/backup.controller.js
+++ b/core/api/backup/backup.controller.js
@@ -81,13 +81,18 @@ module.exports = function BackupController(backupModel, accountModel, logger) {
    * }
    */
   async function initializeMultipartUpload(req, res) {
-    // Generate file destination ID
-    const name = `${uuid.v4()}.enc`;
-    const numberOfParts = Math.ceil(req.body.file_size / CHUNK_SIZE_IN_BYTES);
+    const fileSize = req.body.file_size;
+    if (!Number.isInteger(fileSize) || fileSize <= 0) {
+      throw new BadRequestError('file_size must be a positive integer');
+    }
 
-    if (req.body.file_size > MAX_FILE_SIZE_IN_BYTES) {
+    if (fileSize > MAX_FILE_SIZE_IN_BYTES) {
       throw new BadRequestError(`File is too large. Maximum file size is ${MAX_FILE_SIZE_IN_BYTES / 1024 / 1024} MB.`);
     }
+
+    // Generate file destination ID
+    const name = `${uuid.v4()}.enc`;
+    const numberOfParts = Math.ceil(fileSize / CHUNK_SIZE_IN_BYTES);
 
     const multipartParams = {
       Bucket: process.env.STORAGE_BUCKET,
@@ -120,8 +125,9 @@ module.exports = function BackupController(backupModel, accountModel, logger) {
       { concurrency: 10 },
     );
 
-    // create backup in database with "started" type
-    const backup = await backupModel.createBackup(req.instance.id, null, req.body.file_size, 'started');
+    // create backup in database with "started" type. The S3 key is saved with it so
+    // finalize/abort can only touch the upload this account started.
+    const backup = await backupModel.createBackup(req.instance.id, multipartUpload.Key, fileSize, 'started');
 
     res.send({
       file_id: multipartUpload.UploadId,
@@ -144,13 +150,34 @@ module.exports = function BackupController(backupModel, accountModel, logger) {
    *   "success": true
    * }
    */
+  // The S3 key is never taken from the request body: it is the one saved when this
+  // account initialized the upload, so an instance cannot complete or abort an
+  // upload belonging to another account, nor point its backup to another account's file.
+  async function getStartedBackupKey(instanceId, backupId, fileKeyFromBody) {
+    const backup = await backupModel.getStartedBackup(instanceId, backupId);
+    if (!backup.path) {
+      // upload started before the key was saved with the backup: it cannot be trusted
+      throw new BadRequestError('This upload cannot be resumed, please start a new backup');
+    }
+    if (fileKeyFromBody !== undefined && fileKeyFromBody !== backup.path) {
+      throw new BadRequestError('file_key does not match this backup');
+    }
+    return backup.path;
+  }
+
   async function finalizeMultipartUpload(req, res) {
+    if (!Array.isArray(req.body.parts)) {
+      throw new BadRequestError('parts must be an array');
+    }
+
+    const fileKey = await getStartedBackupKey(req.instance.id, req.body.backup_id, req.body.file_key);
+
     // ordering the parts to make sure they are in the right order
     const partsOrdered = req.body.parts.sort((a, b) => a.PartNumber - b.PartNumber);
 
     const multipartParams = {
       Bucket: process.env.STORAGE_BUCKET,
-      Key: req.body.file_key,
+      Key: fileKey,
       UploadId: req.body.file_id,
       MultipartUpload: {
         Parts: partsOrdered,
@@ -162,7 +189,7 @@ module.exports = function BackupController(backupModel, accountModel, logger) {
       s3Client,
       new GetObjectCommand({
         Bucket: process.env.STORAGE_BUCKET,
-        Key: req.body.file_key,
+        Key: fileKey,
       }),
     );
     const backup = await backupModel.updateBackup(req.instance.id, req.body.backup_id, {
@@ -188,9 +215,11 @@ module.exports = function BackupController(backupModel, accountModel, logger) {
    * }
    */
   async function abortMultiPartUpload(req, res) {
+    const fileKey = await getStartedBackupKey(req.instance.id, req.body.backup_id, req.body.file_key);
+
     const multipartParams = {
       Bucket: process.env.STORAGE_BUCKET,
-      Key: req.body.file_key,
+      Key: fileKey,
       UploadId: req.body.file_id,
     };
 
@@ -198,6 +227,7 @@ module.exports = function BackupController(backupModel, accountModel, logger) {
 
     const backup = await backupModel.updateBackup(req.instance.id, req.body.backup_id, {
       status: 'failed',
+      path: null,
     });
 
     res.send(backup);

--- a/core/api/backup/backup.model.js
+++ b/core/api/backup/backup.model.js
@@ -2,7 +2,11 @@ const path = require('path');
 const { S3Client, DeleteObjectCommand } = require('@aws-sdk/client-s3');
 const retry = require('async-retry');
 
-const { NotFoundError } = require('../../common/error');
+const { NotFoundError, BadRequestError } = require('../../common/error');
+
+const DEFAULT_BACKUP_PAGE_SIZE = 20;
+const MAX_BACKUP_PAGE_SIZE = 100;
+const MAX_BACKUP_PAGINATION_OFFSET = 100000;
 
 module.exports = function BackupModel(logger, db) {
   const s3Client = new S3Client({
@@ -43,9 +47,36 @@ module.exports = function BackupModel(logger, db) {
     return updatedRows[0];
   }
 
-  async function get(instanceId, options) {
-    const offset = options.skip || 0;
-    const limit = options.take || 20;
+  // skip/take come straight from the query string and massive interpolates
+  // OFFSET/LIMIT in the SQL (no bind parameter), so they must be validated as integers
+  function parsePaginationInteger(value, defaultValue, maxValue) {
+    if (value === undefined || value === null || value === '') {
+      return defaultValue;
+    }
+    if (!/^\d+$/.test(String(value))) {
+      throw new BadRequestError('skip and take must be positive integers');
+    }
+    return Math.min(parseInt(value, 10), maxValue);
+  }
+
+  async function getStartedBackup(instanceId, backupId) {
+    const instance = await db.t_instance.findOne({
+      id: instanceId,
+    });
+    const backup = await db.t_backup.findOne({
+      account_id: instance.account_id,
+      id: backupId,
+      status: 'started',
+    });
+    if (backup === null) {
+      throw new NotFoundError('Backup id was not found');
+    }
+    return backup;
+  }
+
+  async function get(instanceId, options = {}) {
+    const offset = parsePaginationInteger(options.skip, 0, MAX_BACKUP_PAGINATION_OFFSET);
+    const limit = parsePaginationInteger(options.take, DEFAULT_BACKUP_PAGE_SIZE, MAX_BACKUP_PAGE_SIZE);
     const instance = await db.t_instance.findOne({
       id: instanceId,
     });
@@ -130,6 +161,7 @@ module.exports = function BackupModel(logger, db) {
   return {
     createBackup,
     get,
+    getStartedBackup,
     updateBackup,
     getBackupPurgeList,
     deleteBackup,

--- a/core/api/google/google.controller.js
+++ b/core/api/google/google.controller.js
@@ -3,6 +3,7 @@
 /* eslint-disable arrow-parens */
 const get = require('get-value');
 const { BadRequestError } = require('../../common/error');
+const { isAllowedRedirectUri, buildRedirectUrl } = require('../../common/oauth-redirect-uri');
 
 const VALID_REDIRECT_URIS = [
   'https://oauth-redirect.googleusercontent.com',
@@ -73,10 +74,10 @@ module.exports = function GoogleController(
         },
       };
 
-      logger.error(`GOOGLE_HOME_SMART_HOME_ERROR, user = ${user.id}`);
-      logger.error(req.body);
-      logger.error(e);
-      logger.error(errorResponse);
+      // the body is not logged: it can contain tokens and device identifiers
+      logger.error(
+        `GOOGLE_HOME_SMART_HOME_ERROR, user = ${user.id}, intent = ${firstOrderIntent}, requestId = ${req.body.requestId}, message = ${e.message}`,
+      );
 
       return res.status(404).json(errorResponse);
     }
@@ -92,14 +93,11 @@ module.exports = function GoogleController(
     if (req.body.client_id !== GOOGLE_HOME_OAUTH_CLIENT_ID) {
       throw new BadRequestError('client_id is not matching');
     }
-    const baseUrlFound = VALID_REDIRECT_URIS.find(
-      (redirectUriBaseUrl) => req.body.redirect_uri && req.body.redirect_uri.startsWith(redirectUriBaseUrl),
-    );
-    if (!baseUrlFound) {
+    if (!isAllowedRedirectUri(req.body.redirect_uri, VALID_REDIRECT_URIS)) {
       throw new BadRequestError('invalid redirect_uri');
     }
     const code = await googleModel.getCode(req.user.id);
-    const redirectUrl = `${req.body.redirect_uri}?state=${req.body.state}&code=${code}`;
+    const redirectUrl = buildRedirectUrl(req.body.redirect_uri, req.body.state, code);
     res.json({
       redirectUrl,
     });

--- a/core/api/google/google.model.js
+++ b/core/api/google/google.model.js
@@ -41,12 +41,12 @@ module.exports = function GoogleHomeModel(logger, db, redisClient, jwtService) {
       throw new ForbiddenError('INVALID_CODE');
     }
     const codeKey = `${GOOGLE_OAUTH_CODE_REDIS_PREFIX}:${code}`;
-    const userId = await redisClient.get(codeKey);
+    // an authorization code is single use: GETDEL reads and removes it atomically,
+    // so two concurrent exchanges cannot both succeed
+    const userId = await redisClient.getDel(codeKey);
     if (userId === null) {
       throw new ForbiddenError('INVALID_CODE');
     }
-    // an authorization code is single use
-    await redisClient.del(codeKey);
     const user = await db.t_user.findOne(
       {
         id: userId,

--- a/core/api/google/google.model.js
+++ b/core/api/google/google.model.js
@@ -37,10 +37,16 @@ module.exports = function GoogleHomeModel(logger, db, redisClient, jwtService) {
   });
 
   async function getRefreshTokenAndAccessToken(code) {
-    const userId = await redisClient.get(`${GOOGLE_OAUTH_CODE_REDIS_PREFIX}:${code}`);
+    if (typeof code !== 'string' || code.length === 0) {
+      throw new ForbiddenError('INVALID_CODE');
+    }
+    const codeKey = `${GOOGLE_OAUTH_CODE_REDIS_PREFIX}:${code}`;
+    const userId = await redisClient.get(codeKey);
     if (userId === null) {
       throw new ForbiddenError('INVALID_CODE');
     }
+    // an authorization code is single use
+    await redisClient.del(codeKey);
     const user = await db.t_user.findOne(
       {
         id: userId,

--- a/core/api/instance/instance.model.js
+++ b/core/api/instance/instance.model.js
@@ -21,13 +21,24 @@ module.exports = function InstanceModel(logger, db, redisClient, jwtService, fin
       throw new ValidationError('instance', error);
     }
 
-    // get the account id of the user
+    // get the account id and role of the user
     const userWithAccount = await db.t_user.findOne(
       {
         id: user.id,
+        is_deleted: false,
       },
-      { fields: ['id', 'account_id'] },
+      { fields: ['id', 'account_id', 'role'] },
     );
+
+    if (userWithAccount === null) {
+      throw new NotFoundError('User not found');
+    }
+
+    // A new instance becomes the primary instance of the account and receives
+    // all the Open API / Google Home / Alexa traffic: only an admin can do that
+    if (userWithAccount.role !== 'admin') {
+      throw new ForbiddenError('You must be admin to create an instance');
+    }
 
     value.id = uuid.v4();
     value.account_id = userWithAccount.account_id;

--- a/core/api/openapi/openapi.controller.js
+++ b/core/api/openapi/openapi.controller.js
@@ -52,7 +52,7 @@ module.exports = function OpenApiController(openApiModel, socketModel) {
    * }
    */
   async function revokeApiKey(req, res, next) {
-    await openApiModel.revokeApiKey(req.params.id);
+    await openApiModel.revokeApiKey(req.user, req.params.id);
     return res.json({ success: true });
   }
 
@@ -69,7 +69,7 @@ module.exports = function OpenApiController(openApiModel, socketModel) {
    * }
    */
   async function updateApiKeyName(req, res, next) {
-    const newApiKey = await openApiModel.updateApiKeyName(req.params.id, req.body.name);
+    const newApiKey = await openApiModel.updateApiKeyName(req.user, req.params.id, req.body.name);
     return res.json(newApiKey);
   }
 

--- a/core/api/openapi/openapi.model.js
+++ b/core/api/openapi/openapi.model.js
@@ -1,7 +1,7 @@
 const Promise = require('bluebird');
 const crypto = require('crypto');
 const Joi = require('joi');
-const { ValidationError } = require('../../common/error');
+const { ValidationError, NotFoundError } = require('../../common/error');
 const schemas = require('../../common/schema');
 
 const randomBytes = Promise.promisify(crypto.randomBytes);
@@ -47,22 +47,49 @@ module.exports = function OpenApiModel(logger, db) {
     return keys;
   }
 
-  async function revokeApiKey(id) {
-    await db.t_open_api_key.update(
+  // Keys are always scoped to the authenticated user: without the user_id
+  // predicate, any user could revoke or rename another user's key by id
+  async function revokeApiKey(user, id) {
+    const updatedKeys = await db.t_open_api_key.update(
       {
         id,
+        user_id: user.id,
+        is_deleted: false,
+        revoked: false,
       },
       { revoked: true },
     );
+
+    if (updatedKeys.length === 0) {
+      throw new NotFoundError('Open API key not found');
+    }
   }
 
-  async function updateApiKeyName(id, name) {
-    await db.t_open_api_key.update(
+  async function updateApiKeyName(user, id, name) {
+    const { error } = Joi.validate({ name }, schemas.openApiSchema, {
+      stripUnknown: true,
+      abortEarly: false,
+      presence: 'required',
+    });
+
+    if (error) {
+      logger.debug(error);
+      throw new ValidationError('open-api-key', error);
+    }
+
+    const updatedKeys = await db.t_open_api_key.update(
       {
         id,
+        user_id: user.id,
+        is_deleted: false,
+        revoked: false,
       },
       { name },
     );
+
+    if (updatedKeys.length === 0) {
+      throw new NotFoundError('Open API key not found');
+    }
 
     return { name };
   }

--- a/core/api/routes.js
+++ b/core/api/routes.js
@@ -16,7 +16,9 @@ module.exports.load = function Routes(app, io, controllers, middlewares) {
     denyUrls: ['/instances/access-token', '/v1/api/owntracks/'],
   });
 
-  app.use(Sentry.Handlers.requestHandler());
+  // headers (Authorization, Stripe signature) and cookies are never sent to Sentry,
+  // the body is kept for debugging but scrubbed by beforeSendSentry
+  app.use(Sentry.Handlers.requestHandler({ request: ['data', 'method', 'query_string', 'url'], ip: false }));
 
   app.use(middlewares.requestExecutionTime);
 
@@ -114,6 +116,7 @@ module.exports.load = function Routes(app, io, controllers, middlewares) {
   );
   app.post(
     '/users/login-two-factor',
+    middlewares.rateLimiter,
     asyncMiddleware(middlewares.twoFactorTokenAuth),
     asyncMiddleware(controllers.userController.loginTwoFactor),
   );
@@ -205,7 +208,7 @@ module.exports.load = function Routes(app, io, controllers, middlewares) {
   );
   app.post(
     '/instances',
-    asyncMiddleware(middlewares.accessTokenAuth({ scope: 'dashboard:read' })),
+    asyncMiddleware(middlewares.accessTokenAuth({ scope: 'dashboard:write' })),
     asyncMiddleware(controllers.instanceController.createInstance),
   );
   app.get(
@@ -239,10 +242,6 @@ module.exports.load = function Routes(app, io, controllers, middlewares) {
   );
 
   // account
-  app.post(
-    '/accounts/subscribe/new',
-    asyncMiddleware(controllers.accountController.subscribeMonthlyPlanWithoutAccount),
-  );
   app.get(
     '/accounts/users',
     asyncMiddleware(middlewares.accessTokenAuth({ scope: 'dashboard:read' })),
@@ -293,8 +292,6 @@ module.exports.load = function Routes(app, io, controllers, middlewares) {
     asyncMiddleware(middlewares.accessTokenAuth({ scope: 'dashboard:read' })),
     asyncMiddleware(controllers.accountController.getInvoices),
   );
-
-  app.post('/accounts/payments/sessions', asyncMiddleware(controllers.accountController.createPaymentSession));
 
   app.get(
     '/accounts/stripe_customer_portal/:stripe_portal_key',

--- a/core/api/socket/socket.controller.js
+++ b/core/api/socket/socket.controller.js
@@ -4,8 +4,9 @@ module.exports = function SocketController(logger, socketModel, io, instanceMode
       // we first authenticate the user thanks to his access token
       const user = await socketModel.authenticateUser(accessToken, socket.id);
 
-      // then he can join two new rooms
+      // then he can join his rooms
       socket.join(`user:${user.id}`);
+      socket.join(socketModel.getUserRoom(user.account_id, user.id));
       socket.join(`account:users:${user.account_id}`);
 
       // on message (request to one instance)
@@ -40,8 +41,9 @@ module.exports = function SocketController(logger, socketModel, io, instanceMode
       // This instance is the primary instance
       await instanceModel.setInstanceAsPrimaryInstance(instance.account_id, instance.id);
 
-      // then he can join two new rooms
+      // then he can join its rooms
       socket.join(`instance:${instance.id}`);
+      socket.join(socketModel.getInstanceRoom(instance.account_id, instance.id));
       socket.join(`account:instances:${instance.account_id}`);
 
       // on message (message to user)
@@ -75,12 +77,24 @@ module.exports = function SocketController(logger, socketModel, io, instanceMode
     );
 
     let isClientAuthenticated = false;
+    // A socket is authenticated at most once: each successful authentication registers
+    // "message" listeners, so re-authenticating would relay every message several times
+    let authenticationInProgress = false;
+
+    const startAuthentication = () => {
+      if (isClientAuthenticated || authenticationInProgress) {
+        return false;
+      }
+      authenticationInProgress = true;
+      return true;
+    };
 
     // if the client has an user token, we authenticate him
-    if (socket.handshake.auth.auth_type === 'user') {
+    if (socket.handshake.auth.auth_type === 'user' && startAuthentication()) {
       const { isAuthenticated, reason } = await authenticateUser(socket, socket.handshake.auth.access_token);
 
       isClientAuthenticated = isAuthenticated;
+      authenticationInProgress = false;
 
       if (isAuthenticated === true) {
         socket.emit('user-authenticated');
@@ -92,10 +106,11 @@ module.exports = function SocketController(logger, socketModel, io, instanceMode
     }
 
     // if the client has an instance token, we authenticate him
-    if (socket.handshake.auth.auth_type === 'instance') {
+    if (socket.handshake.auth.auth_type === 'instance' && startAuthentication()) {
       const { isAuthenticated, reason } = await authenticateInstance(socket, socket.handshake.auth.access_token);
 
       isClientAuthenticated = isAuthenticated;
+      authenticationInProgress = false;
 
       if (isAuthenticated === true) {
         socket.emit('instance-authenticated');
@@ -114,12 +129,25 @@ module.exports = function SocketController(logger, socketModel, io, instanceMode
       }
     }, 90 * 1000);
 
+    const answer = (fn, response) => {
+      if (typeof fn === 'function') {
+        fn(response);
+      }
+    };
+
     socket.on('user-authentication', async (data, fn) => {
-      const { isAuthenticated } = await authenticateUser(socket, data.access_token);
+      // already authenticated (or being authenticated): nothing to redo
+      if (!startAuthentication()) {
+        answer(fn, { authenticated: isClientAuthenticated });
+        return;
+      }
+
+      const { isAuthenticated } = await authenticateUser(socket, data && data.access_token);
 
       isClientAuthenticated = isAuthenticated;
+      authenticationInProgress = false;
       // we answer the client that he is authenticated
-      fn({ authenticated: isAuthenticated });
+      answer(fn, { authenticated: isAuthenticated });
 
       if (isAuthenticated === false) {
         socket.disconnect();
@@ -127,12 +155,19 @@ module.exports = function SocketController(logger, socketModel, io, instanceMode
     });
 
     socket.on('instance-authentication', async (data, fn) => {
-      const { isAuthenticated } = await authenticateInstance(socket, data.access_token);
+      // already authenticated (or being authenticated): nothing to redo
+      if (!startAuthentication()) {
+        answer(fn, { authenticated: isClientAuthenticated });
+        return;
+      }
+
+      const { isAuthenticated } = await authenticateInstance(socket, data && data.access_token);
 
       isClientAuthenticated = isAuthenticated;
+      authenticationInProgress = false;
 
       // we answer the client that he is authenticated
-      fn({ authenticated: isAuthenticated });
+      answer(fn, { authenticated: isAuthenticated });
 
       if (isAuthenticated === false) {
         socket.disconnect();

--- a/core/api/socket/socket.model.js
+++ b/core/api/socket/socket.model.js
@@ -34,8 +34,21 @@ module.exports = function SocketModel(logger, db, redisClient, io, fingerprint, 
     return null;
   });
 
-  async function getInstanceSocketId(instanceId) {
-    const sockets = await io.in(`instance:${instanceId}`).fetchSockets();
+  // Rooms are scoped by account so a user can only reach the instances of his own
+  // account, and an instance can only reach the users of its own account.
+  function getInstanceRoom(accountId, instanceId) {
+    return `account:${accountId}:instance:${instanceId}`;
+  }
+
+  function getUserRoom(accountId, userId) {
+    return `account:${accountId}:user:${userId}`;
+  }
+
+  async function getInstanceSocketId(accountId, instanceId) {
+    if (typeof instanceId !== 'string') {
+      throw new Error('INSTANCE_NOT_FOUND');
+    }
+    const sockets = await io.in(getInstanceRoom(accountId, instanceId)).fetchSockets();
 
     if (sockets.length === 0) {
       throw new Error('INSTANCE_NOT_FOUND');
@@ -134,7 +147,7 @@ module.exports = function SocketModel(logger, db, redisClient, io, fingerprint, 
     message.local_user_id = user.gladys_4_user_id;
 
     try {
-      const socket = await getInstanceSocketId(message.instance_id);
+      const socket = await getInstanceSocketId(user.account_id, message.instance_id);
 
       // If the socket was found on a remote server
       if (socket.constructor.name === 'RemoteSocket') {
@@ -192,9 +205,13 @@ module.exports = function SocketModel(logger, db, redisClient, io, fingerprint, 
     // adding sending instance_id
     message.instance_id = instance.id;
 
-    const roomName = `user:${message.user_id}`;
+    if (typeof message.user_id !== 'string') {
+      logger.warn(`Instance ${instance.id} sent a message without a valid user_id`);
+      return;
+    }
 
-    io.to(roomName).emit('message', message);
+    // the room is scoped by account: a user from another account is never in it
+    io.to(getUserRoom(instance.account_id, message.user_id)).emit('message', message);
   }
 
   async function hello(instance) {
@@ -239,6 +256,8 @@ module.exports = function SocketModel(logger, db, redisClient, io, fingerprint, 
   }
 
   return {
+    getInstanceRoom,
+    getUserRoom,
     authenticateUser,
     authenticateInstance,
     disconnectUser,

--- a/core/api/user/user.model.js
+++ b/core/api/user/user.model.js
@@ -39,20 +39,17 @@ module.exports = function UserModel(logger, db, redisClient, jwtService, mailSer
     return `${TWO_FACTOR_FAILED_ATTEMPTS_REDIS_PREFIX}:${userId}`;
   }
 
-  async function assertTwoFactorAttemptsNotExceeded(userId) {
-    const failedAttempts = await redisClient.get(getTwoFactorAttemptsKey(userId));
-    if (failedAttempts !== null && parseInt(failedAttempts, 10) >= TWO_FACTOR_MAX_FAILED_ATTEMPTS) {
-      logger.warn(`Two factor: too many failed attempts for user ${userId}`);
-      throw new TooManyRequestsError('Too many failed two factor attempts, try again later.');
-    }
-  }
-
-  async function recordFailedTwoFactorAttempt(userId) {
+  // Counts the attempt BEFORE verifying the code, atomically (SET NX EX + INCR in one
+  // MULTI), so concurrent requests cannot all slip under the limit, and the key always
+  // carries a TTL even if the process dies between the two commands.
+  async function countTwoFactorAttempt(userId) {
     const key = getTwoFactorAttemptsKey(userId);
-    const failedAttempts = await redisClient.incr(key);
-    if (failedAttempts === 1) {
-      await redisClient.expire(key, TWO_FACTOR_FAILED_ATTEMPTS_WINDOW_IN_SECONDS);
-    }
+    const [, attempts] = await redisClient
+      .multi()
+      .set(key, 0, { NX: true, EX: TWO_FACTOR_FAILED_ATTEMPTS_WINDOW_IN_SECONDS })
+      .incr(key)
+      .exec();
+    return attempts;
   }
 
   async function resetFailedTwoFactorAttempts(userId) {
@@ -61,7 +58,11 @@ module.exports = function UserModel(logger, db, redisClient, jwtService, mailSer
 
   // Verifies a TOTP code with the per-user failed attempts limit applied
   async function verifyTwoFactorCode(userId, twoFactorSecret, twoFactorCode) {
-    await assertTwoFactorAttemptsNotExceeded(userId);
+    const attempts = await countTwoFactorAttempt(userId);
+    if (attempts > TWO_FACTOR_MAX_FAILED_ATTEMPTS) {
+      logger.warn(`Two factor: too many failed attempts for user ${userId}`);
+      throw new TooManyRequestsError('Too many failed two factor attempts, try again later.');
+    }
 
     const isCodeAStringOrANumber = typeof twoFactorCode === 'string' || typeof twoFactorCode === 'number';
     const tokenValidates = speakeasy.totp.verify({
@@ -71,12 +72,12 @@ module.exports = function UserModel(logger, db, redisClient, jwtService, mailSer
     });
 
     if (!tokenValidates) {
-      await recordFailedTwoFactorAttempt(userId);
       throw new ForbiddenError();
     }
 
     await resetFailedTwoFactorAttempts(userId);
   }
+
   /**
    * Create a new user with his email and language
    */

--- a/core/api/user/user.model.js
+++ b/core/api/user/user.model.js
@@ -5,11 +5,22 @@ const crypto = require('crypto');
 const speakeasy = require('speakeasy');
 const uuid = require('uuid');
 const srpServer = require('secure-remote-password/server');
-const { ValidationError, AlreadyExistError, NotFoundError, ForbiddenError } = require('../../common/error');
+const {
+  ValidationError,
+  AlreadyExistError,
+  NotFoundError,
+  ForbiddenError,
+  TooManyRequestsError,
+} = require('../../common/error');
 const { normalizeEmail } = require('../../common/normalize-email');
 const schema = require('../../common/schema');
 
 const REDIS_LOGIN_SESSION_EXPIRY_IN_SECONDS = 120;
+// A TOTP code has 6 digits and is accepted with a window of 2 steps: without a limit on
+// failed attempts per user, an attacker knowing the password can brute force the code.
+const TWO_FACTOR_MAX_FAILED_ATTEMPTS = 5;
+const TWO_FACTOR_FAILED_ATTEMPTS_WINDOW_IN_SECONDS = 15 * 60;
+const TWO_FACTOR_FAILED_ATTEMPTS_REDIS_PREFIX = 'two_factor_failed_attempts';
 const resetPasswordTokenExpiryInMilliSeconds = 2 * 60 * 60 * 1000;
 const TWO_FACTOR_RECOVERY_CODE_COUNT = 10;
 // 128 bits of entropy per code, so knowing the SHA-256 hash of a code
@@ -24,6 +35,48 @@ function hashTwoFactorRecoveryCode(recoveryCode) {
 }
 
 module.exports = function UserModel(logger, db, redisClient, jwtService, mailService) {
+  function getTwoFactorAttemptsKey(userId) {
+    return `${TWO_FACTOR_FAILED_ATTEMPTS_REDIS_PREFIX}:${userId}`;
+  }
+
+  async function assertTwoFactorAttemptsNotExceeded(userId) {
+    const failedAttempts = await redisClient.get(getTwoFactorAttemptsKey(userId));
+    if (failedAttempts !== null && parseInt(failedAttempts, 10) >= TWO_FACTOR_MAX_FAILED_ATTEMPTS) {
+      logger.warn(`Two factor: too many failed attempts for user ${userId}`);
+      throw new TooManyRequestsError('Too many failed two factor attempts, try again later.');
+    }
+  }
+
+  async function recordFailedTwoFactorAttempt(userId) {
+    const key = getTwoFactorAttemptsKey(userId);
+    const failedAttempts = await redisClient.incr(key);
+    if (failedAttempts === 1) {
+      await redisClient.expire(key, TWO_FACTOR_FAILED_ATTEMPTS_WINDOW_IN_SECONDS);
+    }
+  }
+
+  async function resetFailedTwoFactorAttempts(userId) {
+    await redisClient.del(getTwoFactorAttemptsKey(userId));
+  }
+
+  // Verifies a TOTP code with the per-user failed attempts limit applied
+  async function verifyTwoFactorCode(userId, twoFactorSecret, twoFactorCode) {
+    await assertTwoFactorAttemptsNotExceeded(userId);
+
+    const isCodeAStringOrANumber = typeof twoFactorCode === 'string' || typeof twoFactorCode === 'number';
+    const tokenValidates = speakeasy.totp.verify({
+      secret: twoFactorSecret,
+      token: isCodeAStringOrANumber ? String(twoFactorCode) : '',
+      window: 2,
+    });
+
+    if (!tokenValidates) {
+      await recordFailedTwoFactorAttempt(userId);
+      throw new ForbiddenError();
+    }
+
+    await resetFailedTwoFactorAttempts(userId);
+  }
   /**
    * Create a new user with his email and language
    */
@@ -125,7 +178,7 @@ module.exports = function UserModel(logger, db, redisClient, jwtService, mailSer
   }
 
   async function updateUser(user, data) {
-    const { error, value } = Joi.validate(data, schema.signupSchema, {
+    const { error, value } = Joi.validate(data, schema.updateUserSchema, {
       stripUnknown: true,
       abortEarly: false,
       presence: 'optional',
@@ -480,15 +533,7 @@ module.exports = function UserModel(logger, db, redisClient, jwtService, mailSer
       },
     );
 
-    const tokenValidates = speakeasy.totp.verify({
-      secret: userWithSecret.two_factor_secret,
-      token: twoFactorCode,
-      window: 2,
-    });
-
-    if (!tokenValidates) {
-      throw new ForbiddenError();
-    }
+    await verifyTwoFactorCode(userWithSecret.id, userWithSecret.two_factor_secret, twoFactorCode);
 
     return db.withTransaction((tx) => createDeviceSession(tx, userWithSecret, deviceName, userAgent));
   }
@@ -697,15 +742,11 @@ module.exports = function UserModel(logger, db, redisClient, jwtService, mailSer
     const useRecoveryCode = userWithSecret.two_factor_enabled === true && data.two_factor_recovery_code !== undefined;
 
     if (userWithSecret.two_factor_enabled === true && useRecoveryCode === false) {
-      const tokenValidates = speakeasy.totp.verify({
-        secret: userWithSecret.two_factor_secret,
-        token: data.two_factor_code,
-        window: 2,
-      });
-
-      if (!tokenValidates) {
+      try {
+        await verifyTwoFactorCode(userWithSecret.id, userWithSecret.two_factor_secret, data.two_factor_code);
+      } catch (e) {
         logger.info(`Reset password error: two factor code is not valid.`);
-        throw new ForbiddenError();
+        throw e;
       }
     }
 

--- a/core/common/oauth-redirect-uri.js
+++ b/core/common/oauth-redirect-uri.js
@@ -1,0 +1,55 @@
+/**
+ * Strict validation of an OAuth redirect_uri against an allow list.
+ *
+ * A plain `startsWith` check is bypassable: "https://oauth-redirect.googleusercontent.com.attacker.com"
+ * starts with "https://oauth-redirect.googleusercontent.com". Here the URI is parsed and
+ * the scheme and host must match exactly. The path must match exactly too, except when
+ * the allowed entry has no path (only an origin), in which case any path is accepted.
+ * @param {string} redirectUri - The redirect_uri sent by the client.
+ * @param {Array<string>} allowedRedirectUris - The allow list.
+ * @returns {boolean} True if the redirect_uri is allowed.
+ */
+function isAllowedRedirectUri(redirectUri, allowedRedirectUris) {
+  if (typeof redirectUri !== 'string') {
+    return false;
+  }
+
+  let parsed;
+  try {
+    parsed = new URL(redirectUri);
+  } catch (e) {
+    return false;
+  }
+
+  if (parsed.protocol !== 'https:' || parsed.username || parsed.password) {
+    return false;
+  }
+
+  return allowedRedirectUris.some((allowed) => {
+    const allowedParsed = new URL(allowed);
+    if (parsed.host !== allowedParsed.host) {
+      return false;
+    }
+    const allowedHasPath = allowedParsed.pathname !== '/';
+    return allowedHasPath ? parsed.pathname === allowedParsed.pathname : true;
+  });
+}
+
+/**
+ * Build the URL the browser is redirected to, with state and code safely encoded.
+ * @param {string} redirectUri - The validated redirect_uri.
+ * @param {string} state - The opaque state sent by the OAuth client.
+ * @param {string} code - The authorization code.
+ * @returns {string} The redirect URL.
+ */
+function buildRedirectUrl(redirectUri, state, code) {
+  const url = new URL(redirectUri);
+  url.searchParams.set('state', state === undefined || state === null ? '' : String(state));
+  url.searchParams.set('code', code);
+  return url.toString();
+}
+
+module.exports = {
+  isAllowedRedirectUri,
+  buildRedirectUrl,
+};

--- a/core/common/schema.js
+++ b/core/common/schema.js
@@ -15,6 +15,17 @@ const signupSchema = Joi.object().keys({
   encrypted_backup_key: Joi.string().optional(),
 });
 
+// Fields a logged-in user can change on his profile. The SRP verifier, the encrypted
+// private keys and the backup key are deliberately excluded: changing them is a password
+// change, which must go through the reset-password flow (email token + two factor).
+const updateUserSchema = Joi.object().keys({
+  name: Joi.string().min(2).max(30),
+  email: Joi.string().email(),
+  language: Joi.string().valid(['fr', 'en']),
+  gladys_user_id: Joi.number().optional().allow(null),
+  gladys_4_user_id: Joi.string().optional().allow(null),
+});
+
 const invitationSchema = Joi.object().keys({
   email: Joi.string().email(),
   role: Joi.string(),
@@ -40,6 +51,7 @@ const enedisApiQuerySchema = Joi.object().keys({
 });
 
 module.exports.signupSchema = signupSchema;
+module.exports.updateUserSchema = updateUserSchema;
 module.exports.invitationSchema = invitationSchema;
 module.exports.resetPasswordSchema = resetPasswordSchema;
 module.exports.openApiSchema = openApiSchema;

--- a/core/middleware/accessTokenAuth.js
+++ b/core/middleware/accessTokenAuth.js
@@ -30,8 +30,8 @@ module.exports = function AccessTokenAuthMiddleware(logger) {
 
         next();
       } catch (e) {
-        logger.debug(req.headers.authorization);
-        logger.debug(e);
+        // never log the token itself, only why it was rejected
+        logger.debug(`AccessTokenAuth: ${e.message}`);
         throw new UnauthorizedError();
       }
     };

--- a/core/service/beforeSendSentry.js
+++ b/core/service/beforeSendSentry.js
@@ -1,7 +1,46 @@
 const omitDeep = require('omit-deep');
 
+// Anything that is a credential, a proof, an encrypted key or a location is
+// stripped from the event before it leaves the server, wherever it appears
+// (request body, headers, extra context...)
 const PROPERTIES_TO_OMIT = [
+  // credentials & tokens
   'password',
+  'authorization',
+  'cookie',
+  'cookies',
+  'token',
+  'access_token',
+  'refresh_token',
+  'two_factor_token',
+  'two_factor_code',
+  'two_factor_secret',
+  'two_factor_recovery_code',
+  'recovery_codes',
+  'email_confirmation_token',
+  'api_key',
+  'client_secret',
+  'code',
+  'stripe-signature',
+  'stripe_source_id',
+  'stripe_portal_key',
+  'stream_access_key',
+  'tts_token',
+  // SRP login material
+  'srp_salt',
+  'srp_verifier',
+  'client_ephemeral_public',
+  'client_session_proof',
+  'server_session_proof',
+  'login_session_key',
+  // encrypted user keys
+  'rsa_encrypted_private_key',
+  'ecdsa_encrypted_private_key',
+  'encrypted_backup_key',
+  // Alexa/Google payloads carry the gateway bearer token in there
+  'scope',
+  'grant',
+  // location data
   'latitude',
   'longitude',
   'accuracy',

--- a/core/service/stripe.js
+++ b/core/service/stripe.js
@@ -153,23 +153,6 @@ module.exports = function StripeService(logger) {
     return stripe.webhooks.constructEvent(body, signature, process.env.STRIPE_ENDPOINT_SECRET);
   }
 
-  function createSession(locale) {
-    return stripe.checkout.sessions.create({
-      payment_method_types: ['card'],
-      subscription_data: {
-        // default_tax_rates: [process.env.STRIPE_DEFAULT_TAX_RATE_ID],
-        items: [
-          {
-            plan: process.env.STRIPE_MONTHLY_PLAN_ID,
-          },
-        ],
-      },
-      locale,
-      success_url: `${process.env.GLADYS_WEBSITE_URL}/pricing/success?session_id={CHECKOUT_SESSION_ID}`,
-      cancel_url: `${process.env.GLADYS_WEBSITE_URL}/pricing`,
-    });
-  }
-
   async function createBillingPortalSession(stripeCustomerId) {
     const session = await stripe.billingPortal.sessions.create({
       customer: stripeCustomerId,
@@ -213,7 +196,6 @@ module.exports = function StripeService(logger) {
     verifyEvent,
     getSubscriptionCurrentPeriodEnd,
     getSubscription,
-    createSession,
     getCustomer,
     addTaxRate,
     createBillingPortalSession,

--- a/test/core/api/account/account.controller.test.js
+++ b/test/core/api/account/account.controller.test.js
@@ -36,22 +36,6 @@ describe('POST /accounts/subscribe', () => {
       }));
 });
 
-describe('POST /accounts/subscribe/new', () => {
-  it('should create new customer', () =>
-    request(TEST_BACKEND_APP)
-      .post('/accounts/subscribe/new')
-      .send({
-        email: 'toto@toto.fr',
-      })
-      .set('Accept', 'application/json')
-      .set('Authorization', configTest.jwtAccessTokenDashboard)
-      .expect('Content-Type', /json/)
-      .expect(200)
-      .then((response) => {
-        response.body.should.have.property('current_period_end');
-      }));
-});
-
 describe('POST /accounts/users/:id/revoke', () => {
   it('should revoke a user', () =>
     request(TEST_BACKEND_APP)

--- a/test/core/api/alexa/alexa.controller.test.js
+++ b/test/core/api/alexa/alexa.controller.test.js
@@ -68,6 +68,32 @@ describe('POST /alexa/authorize', () => {
       .expect('Content-Type', /json/)
       .expect(400);
   });
+  it('should return bad request, redirect_uri host only starts with the allowed host', async () => {
+    await request(TEST_BACKEND_APP)
+      .post('/alexa/authorize')
+      .send({
+        redirect_uri: 'https://pitangui.amazon.com.attacker.com/api/skill/link/M1CD0NOTQVDMUV',
+        state: 'toto',
+        client_id: process.env.ALEXA_OAUTH_CLIENT_ID,
+      })
+      .set('Accept', 'application/json')
+      .set('Authorization', configTest.jwtAccessTokenDashboard)
+      .expect('Content-Type', /json/)
+      .expect(400);
+  });
+  it('should return bad request, redirect_uri path only starts with the allowed path', async () => {
+    await request(TEST_BACKEND_APP)
+      .post('/alexa/authorize')
+      .send({
+        redirect_uri: 'https://pitangui.amazon.com/api/skill/link/M1CD0NOTQVDMUVX',
+        state: 'toto',
+        client_id: process.env.ALEXA_OAUTH_CLIENT_ID,
+      })
+      .set('Accept', 'application/json')
+      .set('Authorization', configTest.jwtAccessTokenDashboard)
+      .expect('Content-Type', /json/)
+      .expect(400);
+  });
 });
 
 describe('POST /v1/api/alexa/token', () => {

--- a/test/core/api/backup/backup.controller.test.js
+++ b/test/core/api/backup/backup.controller.test.js
@@ -36,6 +36,94 @@ describe('GET /backups', () => {
   });
 });
 
+describe('GET /backups pagination', () => {
+  it('should accept integer skip and take', async () => {
+    const response = await request(TEST_BACKEND_APP)
+      .get('/backups?skip=1&take=1')
+      .set('Accept', 'application/json')
+      .set('Authorization', configTest.jwtAccessTokenInstance)
+      .expect('Content-Type', /json/)
+      .expect(200);
+    expect(response.body).to.deep.equal([]);
+  });
+  it('should reject a non-integer take (SQL injection attempt)', async () => {
+    const response = await request(TEST_BACKEND_APP)
+      .get('/backups?take=1%20UNION%20SELECT%20srp_verifier%20FROM%20t_user')
+      .set('Accept', 'application/json')
+      .set('Authorization', configTest.jwtAccessTokenInstance)
+      .expect('Content-Type', /json/)
+      .expect(400);
+    expect(response.body).to.have.property('error_code', 'BAD_REQUEST');
+  });
+  it('should reject a non-integer skip', async () => {
+    await request(TEST_BACKEND_APP)
+      .get('/backups?skip=-1')
+      .set('Accept', 'application/json')
+      .set('Authorization', configTest.jwtAccessTokenInstance)
+      .expect('Content-Type', /json/)
+      .expect(400);
+  });
+});
+
+describe('Multipart upload scoping', () => {
+  it('should not finalize an upload started by another account', async () => {
+    const response = await request(TEST_BACKEND_APP)
+      .post('/backups/multi_parts/finalize')
+      .set('Accept', 'application/json')
+      .set('Authorization', configTest.jwtAccessTokenInstance)
+      .send({
+        file_key: 'other-account-started-backup.enc',
+        file_id: 'upload-id',
+        parts: [],
+        backup_id: 'f0b2c4d6-1a3b-4c5d-8e9f-0a1b2c3d4e5f',
+      })
+      .expect('Content-Type', /json/)
+      .expect(404);
+    expect(response.body).to.have.property('error_message', 'Backup id was not found');
+  });
+  it('should not finalize an upload with a file_key that is not the one of the backup', async () => {
+    const response = await request(TEST_BACKEND_APP)
+      .post('/backups/multi_parts/finalize')
+      .set('Accept', 'application/json')
+      .set('Authorization', configTest.jwtAccessTokenInstance)
+      .send({
+        file_key: 'other-account-started-backup.enc',
+        file_id: 'upload-id',
+        parts: [],
+        backup_id: '5c2d0a3e-8f4b-4d3a-9d7e-2a6f1b9c0e11',
+      })
+      .expect('Content-Type', /json/)
+      .expect(400);
+    expect(response.body).to.have.property('error_message', 'file_key does not match this backup');
+  });
+  it('should not abort an upload started by another account', async () => {
+    await request(TEST_BACKEND_APP)
+      .post('/backups/multi_parts/abort')
+      .set('Accept', 'application/json')
+      .set('Authorization', configTest.jwtAccessTokenInstance)
+      .send({
+        file_key: 'other-account-started-backup.enc',
+        file_id: 'upload-id',
+        backup_id: 'f0b2c4d6-1a3b-4c5d-8e9f-0a1b2c3d4e5f',
+      })
+      .expect('Content-Type', /json/)
+      .expect(404);
+    const backup = await TEST_DATABASE_INSTANCE.t_backup.findOne({ id: 'f0b2c4d6-1a3b-4c5d-8e9f-0a1b2c3d4e5f' });
+    expect(backup).to.have.property('status', 'started');
+  });
+  it('should reject an invalid file_size', async () => {
+    await request(TEST_BACKEND_APP)
+      .post('/backups/multi_parts/initialize')
+      .set('Accept', 'application/json')
+      .set('Authorization', configTest.jwtAccessTokenInstance)
+      .send({
+        file_size: 'not-a-number',
+      })
+      .expect('Content-Type', /json/)
+      .expect(400);
+  });
+});
+
 describe('Upload backup', () => {
   it('should upload small backup', async function Test() {
     this.timeout(10000);

--- a/test/core/api/google/google.controller.test.js
+++ b/test/core/api/google/google.controller.test.js
@@ -160,6 +160,41 @@ describe('POST /v1/api/google/token', () => {
     expect(refreshTokenResponse.body).not.to.have.property('refresh_token');
     expect(refreshTokenResponse.body).to.have.property('expires_in');
   });
+  it('should exchange a code only once under concurrent requests', async () => {
+    const response = await request(TEST_BACKEND_APP)
+      .post('/google/authorize')
+      .send({
+        redirect_uri: 'https://oauth-redirect-sandbox.googleusercontent.com/toto',
+        state: 'toto',
+        client_id: process.env.GOOGLE_HOME_OAUTH_CLIENT_ID,
+      })
+      .set('Accept', 'application/json')
+      .set('Authorization', configTest.jwtAccessTokenDashboard)
+      .expect(200);
+    const queryStringToSend = qs.encode({
+      client_id: process.env.GOOGLE_HOME_OAUTH_CLIENT_ID,
+      client_secret: process.env.GOOGLE_HOME_OAUTH_CLIENT_SECRET,
+      code: new URL(response.body.redirectUrl).searchParams.get('code'),
+      grant_type: 'authorization_code',
+    });
+    const responses = await Promise.all(
+      Array.from({ length: 5 }, () =>
+        request(TEST_BACKEND_APP)
+          .post('/v1/api/google/token')
+          .send(queryStringToSend)
+          .set('Accept', 'application/json')
+          .set('Content-Type', 'application/x-www-form-urlencoded'),
+      ),
+    );
+    const statuses = responses.map((tokenResponse) => tokenResponse.status);
+    expect(statuses.filter((status) => status === 200)).to.have.lengthOf(1);
+    expect(statuses.filter((status) => status === 400)).to.have.lengthOf(4);
+    const devices = await TEST_DATABASE_INSTANCE.t_device.find({
+      user_id: 'a139e4a6-ec6c-442d-9730-0499155d38d4',
+      client_id: process.env.GOOGLE_HOME_OAUTH_CLIENT_ID,
+    });
+    expect(devices).to.have.lengthOf(1);
+  });
   it('should return 400 bad request', async () => {
     const response = await request(TEST_BACKEND_APP)
       .post('/google/authorize')

--- a/test/core/api/google/google.controller.test.js
+++ b/test/core/api/google/google.controller.test.js
@@ -59,6 +59,49 @@ describe('POST /google/authorize', () => {
       .expect('Content-Type', /json/)
       .expect(400);
   });
+  it('should return bad request, redirect_uri host only starts with the allowed host', async () => {
+    await request(TEST_BACKEND_APP)
+      .post('/google/authorize')
+      .send({
+        redirect_uri: 'https://oauth-redirect-sandbox.googleusercontent.com.attacker.com/toto',
+        state: 'toto',
+        client_id: process.env.GOOGLE_HOME_OAUTH_CLIENT_ID,
+      })
+      .set('Accept', 'application/json')
+      .set('Authorization', configTest.jwtAccessTokenDashboard)
+      .expect('Content-Type', /json/)
+      .expect(400);
+  });
+  it('should return bad request, redirect_uri is not https', async () => {
+    await request(TEST_BACKEND_APP)
+      .post('/google/authorize')
+      .send({
+        redirect_uri: 'http://oauth-redirect-sandbox.googleusercontent.com/toto',
+        state: 'toto',
+        client_id: process.env.GOOGLE_HOME_OAUTH_CLIENT_ID,
+      })
+      .set('Accept', 'application/json')
+      .set('Authorization', configTest.jwtAccessTokenDashboard)
+      .expect('Content-Type', /json/)
+      .expect(400);
+  });
+  it('should encode the state in the redirect url', async () => {
+    const response = await request(TEST_BACKEND_APP)
+      .post('/google/authorize')
+      .send({
+        redirect_uri: 'https://oauth-redirect-sandbox.googleusercontent.com/toto',
+        state: 'a b&c=d',
+        client_id: process.env.GOOGLE_HOME_OAUTH_CLIENT_ID,
+      })
+      .set('Accept', 'application/json')
+      .set('Authorization', configTest.jwtAccessTokenDashboard)
+      .expect('Content-Type', /json/)
+      .expect(200);
+    const url = new URL(response.body.redirectUrl);
+    expect(url.origin + url.pathname).to.equal('https://oauth-redirect-sandbox.googleusercontent.com/toto');
+    expect(url.searchParams.get('state')).to.equal('a b&c=d');
+    expect(url.searchParams.get('code')).to.have.lengthOf(128);
+  });
 });
 
 describe('POST /v1/api/google/token', () => {
@@ -92,6 +135,14 @@ describe('POST /v1/api/google/token', () => {
     expect(tokenResponse.body).to.have.property('access_token');
     expect(tokenResponse.body).to.have.property('refresh_token');
     expect(tokenResponse.body).to.have.property('expires_in');
+
+    // an authorization code is single use
+    await request(TEST_BACKEND_APP)
+      .post('/v1/api/google/token')
+      .send(queryStringToSend)
+      .set('Accept', 'application/json')
+      .set('Content-Type', 'application/x-www-form-urlencoded')
+      .expect(400);
 
     const queryStringRefreshTokenToSend = qs.encode({
       client_id: process.env.GOOGLE_HOME_OAUTH_CLIENT_ID,

--- a/test/core/api/instance/instance.controllers.test.js
+++ b/test/core/api/instance/instance.controllers.test.js
@@ -1,6 +1,7 @@
 const request = require('supertest');
 const should = require('should');
 const configTest = require('../../../tasks/config');
+const Jwt = require('../../../../core/service/jwt');
 
 describe('GET /instances', () => {
   it('should return list of instances', () =>
@@ -64,6 +65,42 @@ describe('POST /instances', () => {
         response.body.should.have.property('refresh_token');
         response.body.should.have.property('id');
       }));
+
+  it('should not create an instance with a read-only token', () =>
+    request(TEST_BACKEND_APP)
+      .post('/instances')
+      .send({
+        name: 'rasp',
+        rsa_public_key: 'hey',
+        ecdsa_public_key: 'hey',
+      })
+      .set('Accept', 'application/json')
+      .set(
+        'Authorization',
+        Jwt().generateAccessToken({ id: 'a139e4a6-ec6c-442d-9730-0499155d38d4' }, ['dashboard:read']),
+      )
+      .expect('Content-Type', /json/)
+      .expect(401));
+
+  it('should not create an instance when the user is not admin of the account', async () => {
+    await TEST_DATABASE_INSTANCE.t_user.update('a139e4a6-ec6c-442d-9730-0499155d38d4', { role: 'user' });
+    await request(TEST_BACKEND_APP)
+      .post('/instances')
+      .send({
+        name: 'rasp',
+        rsa_public_key: 'hey',
+        ecdsa_public_key: 'hey',
+      })
+      .set('Accept', 'application/json')
+      .set('Authorization', configTest.jwtAccessTokenDashboard)
+      .expect('Content-Type', /json/)
+      .expect(403);
+    const instances = await TEST_DATABASE_INSTANCE.t_instance.find({
+      account_id: 'b2d23f66-487d-493f-8acb-9c8adb400def',
+    });
+    instances.should.have.length(1);
+    instances[0].should.have.property('primary_instance', true);
+  });
 });
 
 describe('GET /instances/access-token', () => {

--- a/test/core/api/openapi/openapi.controller.test.js
+++ b/test/core/api/openapi/openapi.controller.test.js
@@ -1,6 +1,12 @@
 const request = require('supertest');
 const should = require('should');
 const configTest = require('../../../tasks/config');
+const Jwt = require('../../../../core/service/jwt');
+
+// a user of the same account who does not own the fixture key
+// (generated lazily: the JWT secret is set by the test bootstrap)
+const getOtherUserAccessToken = () =>
+  Jwt().generateAccessToken({ id: '3b69f1c5-d36c-419d-884c-50b9dd6e33e4' }, ['dashboard:read', 'dashboard:write']);
 
 describe('POST /open-api-keys', () => {
   it('should create a new open api key', () =>
@@ -55,6 +61,17 @@ describe('DELETE /open-api-keys/:id', () => {
       .set('Authorization', configTest.jwtAccessTokenDashboard)
       .expect('Content-Type', /json/)
       .expect(200));
+
+  it('should not revoke the api key of another user', async () => {
+    await request(TEST_BACKEND_APP)
+      .delete('/open-api-keys/4a01dfc5-899e-4a95-9288-c6096f1be180')
+      .set('Accept', 'application/json')
+      .set('Authorization', getOtherUserAccessToken())
+      .expect('Content-Type', /json/)
+      .expect(404);
+    const key = await TEST_DATABASE_INSTANCE.t_open_api_key.findOne({ id: '4a01dfc5-899e-4a95-9288-c6096f1be180' });
+    key.should.have.property('revoked', false);
+  });
 });
 
 describe('PATCH /open-api-keys/:id', () => {
@@ -71,4 +88,27 @@ describe('PATCH /open-api-keys/:id', () => {
       .then((response) => {
         response.body.should.have.property('name', 'new-name');
       }));
+
+  it('should not update the name of the api key of another user', async () => {
+    await request(TEST_BACKEND_APP)
+      .patch('/open-api-keys/4a01dfc5-899e-4a95-9288-c6096f1be180')
+      .send({
+        name: 'new-name',
+      })
+      .set('Accept', 'application/json')
+      .set('Authorization', getOtherUserAccessToken())
+      .expect('Content-Type', /json/)
+      .expect(404);
+    const key = await TEST_DATABASE_INSTANCE.t_open_api_key.findOne({ id: '4a01dfc5-899e-4a95-9288-c6096f1be180' });
+    key.should.have.property('name', 'Open API Key');
+  });
+
+  it('should return 422 when the name is missing', () =>
+    request(TEST_BACKEND_APP)
+      .patch('/open-api-keys/4a01dfc5-899e-4a95-9288-c6096f1be180')
+      .send({})
+      .set('Accept', 'application/json')
+      .set('Authorization', configTest.jwtAccessTokenDashboard)
+      .expect('Content-Type', /json/)
+      .expect(422));
 });

--- a/test/core/api/socket/socket.controller.test.js
+++ b/test/core/api/socket/socket.controller.test.js
@@ -364,6 +364,153 @@ describe('socket', function Describe() {
     });
   });
 
+  it('should not relay a user message to an instance of another account', async () => {
+    const jwt = Jwt();
+    // instance of another account
+    const otherInstanceId = '7f3c9d2a-5b1e-4c8f-9a6d-2e4b8c1f0a3d';
+    await TEST_DATABASE_INSTANCE.t_instance.insert({
+      id: otherInstanceId,
+      name: 'Other account instance',
+      account_id: 'be2b9666-5c72-451e-98f4-efca76ffef54',
+      rsa_public_key: 'public-key',
+      ecdsa_public_key: 'public-key',
+    });
+
+    const socketInstance = io(`http://localhost:${process.env.SERVER_PORT}`, {
+      auth: { auth_type: 'instance', access_token: jwt.generateAccessTokenInstance({ id: otherInstanceId }) },
+    });
+    const socketUser = io(`http://localhost:${process.env.SERVER_PORT}`, {
+      auth: {
+        auth_type: 'user',
+        access_token: jwt.generateAccessToken({ id: 'a139e4a6-ec6c-442d-9730-0499155d38d4' }, [
+          'dashboard:read',
+          'dashboard:write',
+        ]),
+      },
+    });
+
+    let messagesReceivedByInstance = 0;
+    socketInstance.on('message', (data, cb) => {
+      messagesReceivedByInstance += 1;
+      cb({ response: 'should-not-happen' });
+    });
+
+    await Promise.all([
+      new Promise((resolve) => {
+        socketInstance.on('instance-authenticated', resolve);
+      }),
+      new Promise((resolve) => {
+        socketUser.on('user-authenticated', resolve);
+      }),
+    ]);
+
+    const response = await new Promise((resolve) => {
+      socketUser.emit('message', { data: 'test-data', instance_id: otherInstanceId }, resolve);
+    });
+    expect(response).to.deep.equal({ status: 404, error_code: 'NOT_FOUND', error_message: 'NO_INSTANCE_FOUND' });
+    expect(messagesReceivedByInstance).to.equal(0);
+    socketInstance.disconnect();
+    socketUser.disconnect();
+  });
+
+  it('should not relay an instance message to a user of another account', async () => {
+    const jwt = Jwt();
+    const otherInstanceId = '7f3c9d2a-5b1e-4c8f-9a6d-2e4b8c1f0a3d';
+    await TEST_DATABASE_INSTANCE.t_instance.insert({
+      id: otherInstanceId,
+      name: 'Other account instance',
+      account_id: 'be2b9666-5c72-451e-98f4-efca76ffef54',
+      rsa_public_key: 'public-key',
+      ecdsa_public_key: 'public-key',
+    });
+
+    const socketInstance = io(`http://localhost:${process.env.SERVER_PORT}`, {
+      auth: { auth_type: 'instance', access_token: jwt.generateAccessTokenInstance({ id: otherInstanceId }) },
+    });
+    const socketUser = io(`http://localhost:${process.env.SERVER_PORT}`, {
+      auth: {
+        auth_type: 'user',
+        access_token: jwt.generateAccessToken({ id: 'a139e4a6-ec6c-442d-9730-0499155d38d4' }, [
+          'dashboard:read',
+          'dashboard:write',
+        ]),
+      },
+    });
+
+    let messagesReceivedByUser = 0;
+    socketUser.on('message', () => {
+      messagesReceivedByUser += 1;
+    });
+
+    await Promise.all([
+      new Promise((resolve) => {
+        socketInstance.on('instance-authenticated', resolve);
+      }),
+      new Promise((resolve) => {
+        socketUser.on('user-authenticated', resolve);
+      }),
+    ]);
+
+    socketInstance.emit('message', { data: 'test-data', user_id: 'a139e4a6-ec6c-442d-9730-0499155d38d4' });
+    // give the server time to relay the message if it were to do it
+    await new Promise((resolve) => {
+      setTimeout(resolve, 300);
+    });
+    expect(messagesReceivedByUser).to.equal(0);
+    socketInstance.disconnect();
+    socketUser.disconnect();
+  });
+
+  it('should authenticate a socket only once and relay each message only once', async () => {
+    const jwt = Jwt();
+    const jwtAccessTokenUser = jwt.generateAccessToken({ id: 'a139e4a6-ec6c-442d-9730-0499155d38d4' }, [
+      'dashboard:read',
+      'dashboard:write',
+    ]);
+    const socketInstance = io(`http://localhost:${process.env.SERVER_PORT}`, {
+      auth: {
+        auth_type: 'instance',
+        access_token: jwt.generateAccessTokenInstance({ id: '0bc53f3c-1e11-40d3-99a4-bd392a666eaf' }),
+      },
+    });
+    const socketUser = io(`http://localhost:${process.env.SERVER_PORT}`, {
+      auth: { auth_type: 'user', access_token: jwtAccessTokenUser },
+    });
+
+    let messagesReceivedByInstance = 0;
+    socketInstance.on('message', (data, cb) => {
+      messagesReceivedByInstance += 1;
+      cb({ response: 'response' });
+    });
+
+    await Promise.all([
+      new Promise((resolve) => {
+        socketInstance.on('instance-authenticated', resolve);
+      }),
+      new Promise((resolve) => {
+        socketUser.on('user-authenticated', resolve);
+      }),
+    ]);
+
+    // authenticating again on an already authenticated socket is a no-op
+    const secondAuth = await new Promise((resolve) => {
+      socketUser.emit('user-authentication', { access_token: jwtAccessTokenUser }, resolve);
+    });
+    expect(secondAuth).to.deep.equal({ authenticated: true });
+
+    const response = await new Promise((resolve) => {
+      socketUser.emit('message', { data: 'test-data', instance_id: '0bc53f3c-1e11-40d3-99a4-bd392a666eaf' }, resolve);
+    });
+    expect(response).to.deep.equal({ response: 'response' });
+    // let any duplicated relay arrive before counting
+    await new Promise((resolve) => {
+      setTimeout(resolve, 200);
+    });
+    expect(messagesReceivedByInstance).to.equal(1);
+    socketInstance.disconnect();
+    socketUser.disconnect();
+  });
+
   it('should not connect to socket.io server, wrong scope', (done) => {
     const jwt = Jwt();
 

--- a/test/core/api/user/user.controller.test.js
+++ b/test/core/api/user/user.controller.test.js
@@ -301,6 +301,61 @@ describe('POST /users/login-two-factor', () => {
       .expect('Content-Type', /json/)
       .expect(401)
       .then((response) => {}));
+
+  it('should block the two factor code after too many failed attempts', async () => {
+    const twoFactorSecret = 'N5VTSUKVNBUDKZZFKQZUU2BEJ4SHMYZGNBAE652TO5HWQZ2VPV2Q';
+    const validToken = speakeasy.totp({ secret: twoFactorSecret });
+
+    // 5 failed attempts are allowed
+    for (let i = 0; i < 5; i += 1) {
+      // eslint-disable-next-line no-await-in-loop
+      await request(TEST_BACKEND_APP)
+        .post('/users/login-two-factor')
+        .set('Accept', 'application/json')
+        .set('Authorization', configTest.jwtTwoFactorToken)
+        .send({ two_factor_code: '000000' })
+        .expect('Content-Type', /json/)
+        .expect(403);
+    }
+
+    // the 6th attempt is blocked, even with a valid code
+    const response = await request(TEST_BACKEND_APP)
+      .post('/users/login-two-factor')
+      .set('Accept', 'application/json')
+      .set('Authorization', configTest.jwtTwoFactorToken)
+      .send({ two_factor_code: validToken })
+      .expect('Content-Type', /json/)
+      .expect(429);
+    expect(response.body).to.have.property('error_code', 'TOO_MANY_REQUESTS');
+  });
+
+  it('should reset the failed attempts counter after a successful login', async () => {
+    const twoFactorSecret = 'N5VTSUKVNBUDKZZFKQZUU2BEJ4SHMYZGNBAE652TO5HWQZ2VPV2Q';
+    const validToken = speakeasy.totp({ secret: twoFactorSecret });
+
+    for (let i = 0; i < 4; i += 1) {
+      // eslint-disable-next-line no-await-in-loop
+      await request(TEST_BACKEND_APP)
+        .post('/users/login-two-factor')
+        .set('Accept', 'application/json')
+        .set('Authorization', configTest.jwtTwoFactorToken)
+        .send({ two_factor_code: '000000' })
+        .expect(403);
+    }
+
+    await request(TEST_BACKEND_APP)
+      .post('/users/login-two-factor')
+      .set('Accept', 'application/json')
+      .set('Authorization', configTest.jwtTwoFactorToken)
+      .set('user-agent', 'my-browser-is-awesome')
+      .send({ two_factor_code: validToken })
+      .expect(200);
+
+    const failedAttempts = await TEST_LEGACY_REDIS_CLIENT.v4.get(
+      'two_factor_failed_attempts:a139e4a6-ec6c-442d-9730-0499155d38d4',
+    );
+    expect(failedAttempts).to.equal(null);
+  });
 });
 
 describe('POST /users/two-factor/recovery-codes', () => {
@@ -541,6 +596,46 @@ describe('PATCH /users/me', () => {
         response.body.should.have.property('email', 'new-email@gladysassistant.com');
         response.body.should.have.property('email_confirmed', false);
       }));
+
+  it('should not change the password (SRP verifier) nor the keys with an access token', async () => {
+    const userBefore = await TEST_DATABASE_INSTANCE.t_user.findOne({ id: 'a139e4a6-ec6c-442d-9730-0499155d38d4' });
+    await request(TEST_BACKEND_APP)
+      .patch('/users/me')
+      .set('Accept', 'application/json')
+      .set('Authorization', configTest.jwtAccessTokenDashboard)
+      .send({
+        name: 'still me',
+        srp_salt: 'attacker-salt',
+        srp_verifier: 'attacker-verifier',
+        rsa_public_key: 'attacker-key',
+        rsa_encrypted_private_key: 'attacker-key',
+        ecdsa_public_key: 'attacker-key',
+        ecdsa_encrypted_private_key: 'attacker-key',
+        encrypted_backup_key: 'attacker-key',
+      })
+      .expect('Content-Type', /json/)
+      .expect(200);
+    const userAfter = await TEST_DATABASE_INSTANCE.t_user.findOne({ id: 'a139e4a6-ec6c-442d-9730-0499155d38d4' });
+    expect(userAfter.name).to.equal('still me');
+    expect(userAfter.srp_salt).to.equal(userBefore.srp_salt);
+    expect(userAfter.srp_verifier).to.equal(userBefore.srp_verifier);
+    expect(userAfter.rsa_public_key).to.equal(userBefore.rsa_public_key);
+    expect(userAfter.rsa_encrypted_private_key).to.equal(userBefore.rsa_encrypted_private_key);
+    expect(userAfter.ecdsa_public_key).to.equal(userBefore.ecdsa_public_key);
+    expect(userAfter.ecdsa_encrypted_private_key).to.equal(userBefore.ecdsa_encrypted_private_key);
+    expect(userAfter.encrypted_backup_key).to.equal(userBefore.encrypted_backup_key);
+  });
+
+  it('should return 422 for an unsupported language', () =>
+    request(TEST_BACKEND_APP)
+      .patch('/users/me')
+      .set('Accept', 'application/json')
+      .set('Authorization', configTest.jwtAccessTokenDashboard)
+      .send({
+        language: 'zz',
+      })
+      .expect('Content-Type', /json/)
+      .expect(422));
 });
 
 describe('GET /users/me', () => {

--- a/test/core/api/user/user.controller.test.js
+++ b/test/core/api/user/user.controller.test.js
@@ -329,6 +329,27 @@ describe('POST /users/login-two-factor', () => {
     expect(response.body).to.have.property('error_code', 'TOO_MANY_REQUESTS');
   });
 
+  it('should hold the attempts limit under concurrent requests', async () => {
+    // 20 wrong codes sent in parallel: at most 5 reach the TOTP verification (403),
+    // the others are rejected by the counter (429)
+    const responses = await Promise.all(
+      Array.from({ length: 20 }, () =>
+        request(TEST_BACKEND_APP)
+          .post('/users/login-two-factor')
+          .set('Accept', 'application/json')
+          .set('Authorization', configTest.jwtTwoFactorToken)
+          .send({ two_factor_code: '000000' }),
+      ),
+    );
+    const statuses = responses.map((response) => response.status);
+    expect(statuses.filter((status) => status === 403)).to.have.lengthOf(5);
+    expect(statuses.filter((status) => status === 429)).to.have.lengthOf(15);
+    const ttl = await TEST_LEGACY_REDIS_CLIENT.v4.ttl(
+      'two_factor_failed_attempts:a139e4a6-ec6c-442d-9730-0499155d38d4',
+    );
+    expect(ttl).to.be.above(0);
+  });
+
   it('should reset the failed attempts counter after a successful login', async () => {
     const twoFactorSecret = 'N5VTSUKVNBUDKZZFKQZUU2BEJ4SHMYZGNBAE652TO5HWQZ2VPV2Q';
     const validToken = speakeasy.totp({ secret: twoFactorSecret });

--- a/test/core/common/oauth-redirect-uri.test.js
+++ b/test/core/common/oauth-redirect-uri.test.js
@@ -1,0 +1,65 @@
+const { expect } = require('chai');
+
+const { isAllowedRedirectUri, buildRedirectUrl } = require('../../../core/common/oauth-redirect-uri');
+
+const GOOGLE_ALLOWED = [
+  'https://oauth-redirect.googleusercontent.com',
+  'https://oauth-redirect-sandbox.googleusercontent.com',
+];
+const ALEXA_ALLOWED = ['https://pitangui.amazon.com/api/skill/link/M1CD0NOTQVDMUV'];
+
+describe('oauth-redirect-uri', () => {
+  describe('isAllowedRedirectUri', () => {
+    it('should accept any path when the allowed entry is an origin', () => {
+      expect(
+        isAllowedRedirectUri('https://oauth-redirect.googleusercontent.com/r/project-id', GOOGLE_ALLOWED),
+      ).to.equal(true);
+      expect(isAllowedRedirectUri('https://oauth-redirect-sandbox.googleusercontent.com', GOOGLE_ALLOWED)).to.equal(
+        true,
+      );
+    });
+    it('should require an exact path when the allowed entry has a path', () => {
+      expect(isAllowedRedirectUri('https://pitangui.amazon.com/api/skill/link/M1CD0NOTQVDMUV', ALEXA_ALLOWED)).to.equal(
+        true,
+      );
+      expect(
+        isAllowedRedirectUri('https://pitangui.amazon.com/api/skill/link/M1CD0NOTQVDMUVX', ALEXA_ALLOWED),
+      ).to.equal(false);
+      expect(isAllowedRedirectUri('https://pitangui.amazon.com/api/skill/link/', ALEXA_ALLOWED)).to.equal(false);
+    });
+    it('should reject a host that only starts with the allowed host', () => {
+      expect(
+        isAllowedRedirectUri('https://oauth-redirect.googleusercontent.com.attacker.com/toto', GOOGLE_ALLOWED),
+      ).to.equal(false);
+      expect(isAllowedRedirectUri('https://oauth-redirect.googleusercontent.com:8443/toto', GOOGLE_ALLOWED)).to.equal(
+        false,
+      );
+    });
+    it('should reject credentials in the URL', () => {
+      expect(
+        isAllowedRedirectUri('https://oauth-redirect.googleusercontent.com@attacker.com/toto', GOOGLE_ALLOWED),
+      ).to.equal(false);
+    });
+    it('should reject non https, invalid and non string values', () => {
+      expect(isAllowedRedirectUri('http://oauth-redirect.googleusercontent.com/toto', GOOGLE_ALLOWED)).to.equal(false);
+      expect(isAllowedRedirectUri('not-a-url', GOOGLE_ALLOWED)).to.equal(false);
+      expect(isAllowedRedirectUri(undefined, GOOGLE_ALLOWED)).to.equal(false);
+      expect(isAllowedRedirectUri({ startsWith: () => true }, GOOGLE_ALLOWED)).to.equal(false);
+    });
+  });
+
+  describe('buildRedirectUrl', () => {
+    it('should encode state and code as query parameters', () => {
+      const url = new URL(
+        buildRedirectUrl('https://oauth-redirect.googleusercontent.com/r/id', 'a b&c=d#e', 'the-code'),
+      );
+      expect(url.origin + url.pathname).to.equal('https://oauth-redirect.googleusercontent.com/r/id');
+      expect(url.searchParams.get('state')).to.equal('a b&c=d#e');
+      expect(url.searchParams.get('code')).to.equal('the-code');
+    });
+    it('should tolerate a missing state', () => {
+      const url = new URL(buildRedirectUrl('https://oauth-redirect.googleusercontent.com/r/id', undefined, 'the-code'));
+      expect(url.searchParams.get('state')).to.equal('');
+    });
+  });
+});

--- a/test/tasks/fixtures/t_backup.js
+++ b/test/tasks/fixtures/t_backup.js
@@ -18,6 +18,26 @@ module.exports = [
     updated_at: '2018-10-16T02:21:25.901Z',
   },
   {
+    // upload in progress: path holds the S3 key of the multipart upload
+    id: '5c2d0a3e-8f4b-4d3a-9d7e-2a6f1b9c0e11',
+    path: 'started-backup.enc',
+    size: 1000,
+    account_id: 'b2d23f66-487d-493f-8acb-9c8adb400def',
+    status: 'started',
+    created_at: '2018-10-16T02:21:25.901Z',
+    updated_at: '2018-10-16T02:21:25.901Z',
+  },
+  {
+    // upload in progress of another account
+    id: 'f0b2c4d6-1a3b-4c5d-8e9f-0a1b2c3d4e5f',
+    path: 'other-account-started-backup.enc',
+    size: 1000,
+    account_id: 'be2b9666-5c72-451e-98f4-efca76ffef54',
+    status: 'started',
+    created_at: '2018-10-16T02:21:25.901Z',
+    updated_at: '2018-10-16T02:21:25.901Z',
+  },
+  {
     id: '72543b45-246b-49fc-be16-d728c46d7060',
     path: `https://${process.env.STORAGE_BUCKET}.${process.env.STORAGE_ENDPOINT}/un-backup.enc`,
     size: 1000,


### PR DESCRIPTION
## Summary

Fixes from the security audit of the gateway, in one PR as requested.

| # | Issue | Fix |
|---|---|---|
| 1 | **SQL injection on `GET /backups`** – `skip`/`take` from the query string were passed straight to massive, which interpolates `OFFSET`/`LIMIT` in the SQL | `backup.model.js` validates both as bounded integers (`^\d+$`, take ≤ 100) and returns 400 otherwise |
| 2 | **TOTP brute force** – `/users/login-two-factor` had no rate limit, the 2FA token is valid 2 min and the TOTP window is 2 | Failed attempts are limited per user (5 per 15 min, Redis counter, reset on success) on login **and** password reset. The route also gets the per-IP rate limiter |
| 3 | **Password / keys change without re-auth** – `PATCH /users/me` used the signup schema and accepted `srp_verifier`, `srp_salt`, RSA/ECDSA keys, `encrypted_backup_key` | Dedicated `updateUserSchema` (name, email, language, gladys ids only). Password changes go through the reset-password flow |
| 4 | **IDOR on Open API keys** – revoke / rename by id without owner check | Both queries are scoped to `user_id`, 404 when no row matches. Rename now validates `name` |
| 5 | **WebSocket relay without ownership check** – any authenticated user could target any `instance_id`, any instance any `user_id` | Rooms are scoped by account (`account:<id>:instance:<id>` / `account:<id>:user:<id>`); a target outside the account is simply not in the room |
| 6 | **Multipart backup not scoped** – `file_key`/`file_id` from the body were used as-is on S3 | The S3 key is stored with the `started` backup at initialize; finalize/abort resolve the key from the account-scoped backup row and reject a mismatching `file_key` |
| 7 | **`startsWith` on OAuth `redirect_uri`** | New `core/common/oauth-redirect-uri.js`: parsed URL, https only, exact host match, exact path when the allow-list entry has one. `state`/`code` are URL-encoded. Authorization codes are now single use |
| 8 | **Public payment routes without rate limit** | `/accounts/subscribe/new` and `/accounts/payments/sessions` removed with their controller/model/stripe code. Account creation goes through the Stripe Checkout webhook only |
| 9 | **Instance creation too permissive** | `POST /instances` requires `dashboard:write` and the `admin` role |
| 10 | **Secrets in logs and Sentry** | Authorization header no longer logged on auth failure; Google/Alexa bodies (which carry the gateway bearer token) no longer logged. Sentry request handler no longer sends headers/cookies, and `beforeSendSentry` scrubs tokens, codes, SRP material, encrypted keys |
| 11 | **Duplicated socket listeners** | A socket authenticates at most once; a second `user-authentication` / `instance-authentication` returns the current state without registering new listeners |

## Behaviour changes to be aware of

- `PATCH /users/me` silently drops SRP / key fields (`stripUnknown`), and returns 422 for a language other than `fr`/`en`.
- `POST /instances` now returns 403 for a non-admin member of the account.
- `GET /backups?take=…` returns 400 for a non-integer value instead of executing it.
- `POST /backups/multi_parts/finalize|abort` for an upload started **before** this deploy (no key stored) returns 400 asking to restart the backup.
- An OAuth authorization code can only be exchanged once.

## Tests

- New tests for every fix (SQL injection attempt, 2FA lockout + reset on success, PATCH /users/me field stripping, Open API key IDOR, cross-account socket relay both ways, single socket authentication, multipart scoping, redirect_uri bypasses, single-use code, instance creation role/scope) plus unit tests for the redirect_uri helper.
- Locally with Postgres + Redis: **340 passing**, 15 failing. The 15 failures are the S3 upload/camera tests that need real AWS credentials and fail identically on `master` in this environment; they run with the repository secrets in CI.
- `npm run eslint` and `npm run prettier-check` are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ad5tam5koW5peETQeGQQXH

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ad5tam5koW5peETQeGQQXH)_