### PR TITLE
Docker: Node 24, non-root user, npm ci, MaxMind key kept out of the image

### DIFF
--- a/.github/workflows/test-and-build.yml
+++ b/.github/workflows/test-and-build.yml
@@ -79,7 +79,7 @@ jobs:
       - name: 💽 Setup nodejs
         uses: actions/setup-node@v3
         with:
-          node-version: 18
+          node-version: 24
       - name: Get npm cache directory
         id: npm-cache-dir
         run: |
@@ -157,8 +157,10 @@ jobs:
           DOCKERHUB_USER: ${{ secrets.DOCKERHUB_USER }}
           DOCKERHUB_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD }}
       - name: Docker build
-        run: docker build --build-arg MAX_MIND_LICENSE_KEY="${{ secrets.MAX_MIND_LICENSE_KEY }}" -t gladysassistant/gladys-gateway-server:latest .
+        # The MaxMind key is passed as a BuildKit secret: it is only mounted
+        # during the build step and never persisted in the image.
+        run: docker build --secret id=maxmind_license_key,env=MAX_MIND_LICENSE_KEY -t gladysassistant/gladys-gateway-server:latest .
         env:
-          DOCKERHUB_USER: ${{ secrets.MAX_MIND_LICENSE_KEY }}
+          MAX_MIND_LICENSE_KEY: ${{ secrets.MAX_MIND_LICENSE_KEY }}
       - name: Docker push
         run: docker push gladysassistant/gladys-gateway-server:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,25 +1,43 @@
-FROM node:18-alpine
+# syntax=docker/dockerfile:1
 
-ARG MAX_MIND_LICENSE_KEY
-ENV MAX_MIND_LICENSE_KEY=$MAX_MIND_LICENSE_KEY
+# ---------- Build stage: install production dependencies ----------
+FROM node:24-alpine AS build
+
+WORKDIR /src
+
+# Toolchain needed to compile the few optional native modules
+RUN apk add --no-cache make gcc g++ python3 git
+
+COPY package.json package-lock.json ./
+
+# Reproducible install from the lockfile, production dependencies only
+RUN npm ci --omit=dev && npm cache clean --force
+
+# Optionally refresh the GeoIP database at build time.
+# The MaxMind key is read from a BuildKit secret, so it is never stored
+# in an image layer, in the image config or visible via `docker inspect`.
+# Build with: docker build --secret id=maxmind_license_key,env=MAX_MIND_LICENSE_KEY .
+RUN --mount=type=secret,id=maxmind_license_key \
+  if [ -s /run/secrets/maxmind_license_key ]; then \
+    cd node_modules/geoip-lite && \
+    LICENSE_KEY="$(cat /run/secrets/maxmind_license_key)" npm run-script updatedb; \
+  fi
+
+# ---------- Runtime stage ----------
+FROM node:24-alpine
 
 # Add tzdata for timezone settings
 RUN apk add --no-cache tzdata
 
-# Create src folder
-RUN mkdir /src
-
 WORKDIR /src
-ADD . /src
 
-RUN apk add --no-cache --virtual .build-deps make gcc g++ python3 git && \
-  npm install && apk del .build-deps
+COPY --chown=node:node --from=build /src/node_modules ./node_modules
+COPY --chown=node:node . .
 
-RUN if [[ -n "$MAX_MIND_LICENSE_KEY" ]] ; \
-  then cd node_modules/geoip-lite && npm run-script updatedb license_key=$MAX_MIND_LICENSE_KEY; \
-  fi
+# Run as the unprivileged `node` user shipped with the base image
+USER node
 
 # Export listening port
 EXPOSE 3000
 
-CMD ["node" ,"index.js"]
+CMD ["node", "index.js"]

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "1.0.0",
   "description": "An End-to-End Encrypted Gateway to access Gladys from the internet",
   "main": "index.js",
+  "engines": {
+    "node": ">=24"
+  },
   "scripts": {
     "test": "mocha ./test/bootstrap.test.js ./test/**/*.test.js --exit",
     "coverage": "nyc --reporter=lcov npm test",


### PR DESCRIPTION
## Problem

- The image was built on `node:18-alpine`. Node 18 reached end of life in April 2025 and no longer receives security fixes.
- The container ran as `root` and installed dependencies with `npm install` instead of a reproducible `npm ci` from the lockfile.
- The MaxMind license key was passed as a build `ARG` and copied into an `ENV`, so it was persisted in the image config and readable with `docker inspect gladysassistant/gladys-gateway-server:latest` on Docker Hub.

## Changes

**Dockerfile**
- Base image is now `node:24-alpine` (current active LTS).
- Multi-stage build: a build stage installs dependencies with `npm ci --omit=dev` and runs the optional GeoIP database refresh. The runtime stage only ships `node_modules` and the sources, with no compiler toolchain.
- The runtime stage switches to the unprivileged `node` user shipped with the base image (files are copied with `--chown=node:node`).
- The MaxMind key is now mounted as a BuildKit secret (`RUN --mount=type=secret,id=maxmind_license_key`) for the duration of the GeoIP update step only. It is passed to geoip-lite through the `LICENSE_KEY` environment variable of that single command, so it is never written to a layer, to the image config, or to the image history.

**CI (`.github/workflows/test-and-build.yml`)**
- Tests run on Node 24.
- The master build passes the key with `docker build --secret id=maxmind_license_key,env=MAX_MIND_LICENSE_KEY` instead of `--build-arg`. The PR build job still works without the secret (the update step is skipped when the secret is absent).

**package.json**
- Declares `engines.node >= 24`.

## Validation

- `npm ci --omit=dev` with Node 24 in a clean directory, then loading `core/index`, the worker entrypoint and `geoip-lite` (lookup works) with production-only dependencies.
- `npm run eslint` and `npm run prettier-check` pass on Node 24.
- Full mocha suite run locally on both Node 22 and Node 24 against Postgres 16 and Redis: identical results (306 passing). The remaining failures are the same on both versions and are caused by the local sandbox (no AWS credentials, outbound HTTP calls blocked), not by the Node upgrade.
- The Docker image could not be built in this sandbox (no Docker daemon); the `Docker build` CI job on this PR covers that.

## Note for the existing published image

Because the key was baked into previous images, the tag currently on Docker Hub still exposes it. Rotating the MaxMind license key after this is merged and a new image is pushed is recommended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01332wmrVFf5achjywN4d6Sq

---
_Generated by [Claude Code](https://claude.ai/code/session_01332wmrVFf5achjywN4d6Sq)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the supported Node.js version to 24 or newer.
  * Improved production container builds by using a smaller, multi-stage image.
  * Enhanced container security by running the application as a non-privileged user.
  * Secured MaxMind license handling during image builds.
  * Updated automated test and build workflows to use Node.js 24.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->