### PR TITLE
CI: release process based on Git tags for Docker images

### DIFF
--- a/.github/workflows/create-release-tag.yml
+++ b/.github/workflows/create-release-tag.yml
@@ -32,12 +32,18 @@ jobs:
       - name: 🔍 Read the version to tag
         id: version
         run: |
-          TAG="v$(node -p "require('./package.json').version")"
-          # package.json also changes for plain dependency updates: only an
-          # unreleased version is worth tagging. An empty output skips the
-          # remaining steps.
+          VERSION=$(node -p "require('./package.json').version")
+          TAG="v${VERSION}"
+          # package.json also changes for plain dependency updates: only a
+          # version bump is worth tagging. Comparing with the parent commit
+          # (the previous tip of master) rather than relying on an existing
+          # tag also covers the very first release, when no tag exists yet.
+          # An empty output skips the remaining steps.
+          PREVIOUS_VERSION=$(git show "${GITHUB_SHA}^:package.json" | node -p "JSON.parse(require('fs').readFileSync(0, 'utf8')).version")
           TAGGED_COMMIT=$(git rev-parse -q --verify "refs/tags/${TAG}^{commit}" || true)
-          if [ -z "${TAGGED_COMMIT}" ]; then
+          if [ "${VERSION}" = "${PREVIOUS_VERSION}" ] && [ "${TAGGED_COMMIT}" != "${GITHUB_SHA}" ]; then
+            echo "Version ${VERSION} is unchanged since the previous commit, nothing to release."
+          elif [ -z "${TAGGED_COMMIT}" ]; then
             echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
             echo "create=true" >> "$GITHUB_OUTPUT"
           elif [ "${TAGGED_COMMIT}" = "${GITHUB_SHA}" ]; then

--- a/.github/workflows/create-release-tag.yml
+++ b/.github/workflows/create-release-tag.yml
@@ -1,0 +1,98 @@
+name: Create release tag
+
+# Step 2 of the release process. Tags master as soon as the version in
+# package.json changes, whether the bump came from the "Prepare release"
+# workflow or was pushed by hand. Editing the version field in an unrelated
+# pull request therefore ships a release: it is not a casually editable field.
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - package.json
+
+permissions:
+  contents: write
+  # Needed to dispatch the Docker release workflow on the new tag.
+  actions: write
+
+concurrency:
+  group: create-release-tag
+  cancel-in-progress: false
+
+jobs:
+  create-release-tag:
+    name: Tag the new version
+    runs-on: ubuntu-latest
+    steps:
+      - name: ⬇️ Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: 🔍 Read the version to tag
+        id: version
+        run: |
+          TAG="v$(node -p "require('./package.json').version")"
+          # package.json also changes for plain dependency updates: only an
+          # unreleased version is worth tagging. An empty output skips the
+          # remaining steps.
+          TAGGED_COMMIT=$(git rev-parse -q --verify "refs/tags/${TAG}^{commit}" || true)
+          if [ -z "${TAGGED_COMMIT}" ]; then
+            echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
+            echo "create=true" >> "$GITHUB_OUTPUT"
+          elif [ "${TAGGED_COMMIT}" = "${GITHUB_SHA}" ]; then
+            # The tag was created by an earlier attempt on this very commit, which
+            # then failed. Keep going, without recreating it, so re-running the job
+            # replays the dispatch it never reached.
+            echo "Tag ${TAG} already points at this commit, replaying the dispatch."
+            echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
+          else
+            echo "Tag ${TAG} already exists on another commit, nothing to release."
+          fi
+      - name: 🔧 Configure git
+        if: steps.version.outputs.create
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+      - name: 🔖 Create and push the tag
+        if: steps.version.outputs.create
+        env:
+          TAG: ${{ steps.version.outputs.tag }}
+        run: |
+          git tag -a "${TAG}" -m "${TAG}"
+          git push origin "refs/tags/${TAG}"
+      - name: 🎬 Trigger the Docker release workflow
+        if: steps.version.outputs.tag
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          TAG: ${{ steps.version.outputs.tag }}
+        run: |
+          # A tag pushed with the default GITHUB_TOKEN does not trigger the
+          # workflows listening on `push: tags`, so the release workflow is
+          # dispatched explicitly on the new tag. workflow_dispatch is one of the
+          # two events GitHub does start from a GITHUB_TOKEN, so no PAT is needed.
+          # The tag was pushed a second ago and may not be visible to the API yet.
+          for attempt in 1 2 3; do
+            if gh workflow run docker-release-build.yml --ref "${TAG}"; then
+              break
+            fi
+            if [ "${attempt}" = 3 ]; then
+              echo "::error::Could not dispatch docker-release-build.yml on ${TAG}. Re-run this job to replay the dispatch."
+              exit 1
+            fi
+            echo "Dispatch failed, retrying in 5s (attempt ${attempt}/3)"
+            sleep 5
+          done
+      - name: 📝 Job summary
+        if: steps.version.outputs.tag
+        env:
+          TAG: ${{ steps.version.outputs.tag }}
+          REPO_URL: ${{ github.server_url }}/${{ github.repository }}
+        run: |
+          {
+            echo "### 🚀 Release ${TAG} created"
+            echo ""
+            echo "- Tag: [\`${TAG}\`](${REPO_URL}/releases/tag/${TAG})"
+            echo "- Docker release workflow dispatched on the tag"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/docker-release-build.yml
+++ b/.github/workflows/docker-release-build.yml
@@ -1,0 +1,64 @@
+name: Release Docker image
+run-name: Release Docker image ${{ github.ref_name }}
+
+# Step 3 of the release process. Builds the production image from a release
+# tag and pushes it to Docker Hub as `vX.Y.Z` and `latest`. Rolling back a
+# release is then a matter of deploying the previous `vX.Y.Z` tag.
+
+on:
+  # Dispatched on the new tag by the "Create release tag" workflow: a tag pushed
+  # with the default GITHUB_TOKEN does not trigger the `push` event below.
+  workflow_dispatch:
+  push:
+    tags:
+      - 'v*.*.*'
+
+jobs:
+  docker:
+    name: Docker build and push
+    # Production images are only published from a release tag, never from a
+    # branch a manual dispatch could have been started on.
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    steps:
+      - name: ⬇️ Checkout code
+        uses: actions/checkout@v4
+      - name: 🐳 Docker meta
+        id: docker_meta
+        uses: docker/metadata-action@v5
+        with:
+          images: gladysassistant/gladys-gateway-server
+          # `latest` is pushed on every stable release: the `auto` flavor adds
+          # it on semver tags but skips pre-releases (v1.2.0-rc.1).
+          flavor: |
+            latest=auto
+          tags: |
+            type=semver,pattern=v{{version}}
+      - name: 🐳 Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: 🔑 Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USER }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+      - name: 🐳 Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          pull: true
+          tags: ${{ steps.docker_meta.outputs.tags }}
+          labels: ${{ steps.docker_meta.outputs.labels }}
+          # The MaxMind key is passed as a BuildKit secret: it is only mounted
+          # during the build step and never persisted in the image.
+          secrets: |
+            maxmind_license_key=${{ secrets.MAX_MIND_LICENSE_KEY }}
+      - name: 📝 Job summary
+        env:
+          TAGS: ${{ steps.docker_meta.outputs.tags }}
+        run: |
+          {
+            echo "### 🐳 Docker images published"
+            echo ""
+            echo "${TAGS}" | sed 's/^/- `/; s/$/`/'
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/docker-release-build.yml
+++ b/.github/workflows/docker-release-build.yml
@@ -13,6 +13,13 @@ on:
     tags:
       - 'v*.*.*'
 
+# Two close releases must not publish in parallel: with `latest` pushed on
+# every release, a faster build of a newer tag could be overtaken by an older
+# one. Publishes are serialized the same way tag creation is.
+concurrency:
+  group: docker-release
+  cancel-in-progress: false
+
 jobs:
   docker:
     name: Docker build and push

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -1,0 +1,107 @@
+name: Prepare release
+run-name: Prepare ${{ inputs.release_type }} release
+
+# Step 1 of the release process, started from the Actions tab ("Run workflow").
+# It bumps the version in package.json on a `release/vX.Y.Z` branch and links
+# to the pull request to open. Merging that pull request triggers the
+# "Create release tag" workflow, which tags master and publishes the Docker
+# image (see create-release-tag.yml and docker-release-build.yml).
+
+on:
+  workflow_dispatch:
+    inputs:
+      release_type:
+        description: 'Type of version bump'
+        required: true
+        default: 'patch'
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+
+permissions:
+  contents: write
+
+# Two overlapping runs would bump from the same tip and race on the same version.
+concurrency:
+  group: prepare-release
+  cancel-in-progress: false
+
+jobs:
+  prepare-release:
+    name: Bump version on a release branch
+    runs-on: ubuntu-latest
+    steps:
+      - name: 🛑 Ensure workflow runs on master
+        if: github.ref != 'refs/heads/master'
+        env:
+          REF_NAME: ${{ github.ref_name }}
+        run: |
+          echo "::error::This workflow can only be run on master, got ${REF_NAME}."
+          exit 1
+      - name: ⬇️ Checkout code
+        uses: actions/checkout@v4
+        with:
+          # Always release from the current tip of master, not from the commit
+          # master pointed at when the workflow was dispatched.
+          ref: master
+          fetch-depth: 0
+      - name: 💽 Setup nodejs
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+      - name: 🔧 Configure git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+      - name: 🔖 Bump version on a release branch
+        id: bump
+        env:
+          RELEASE_TYPE: ${{ inputs.release_type }}
+        run: |
+          npm version "${RELEASE_TYPE}" --no-git-tag-version
+          VERSION=$(node -p "require('./package.json').version")
+          TAG="v${VERSION}"
+          if git rev-parse -q --verify "refs/tags/${TAG}" >/dev/null; then
+            echo "::error::Tag ${TAG} already exists, master may not have been released yet."
+            exit 1
+          fi
+          BRANCH="release/${TAG}"
+          if git ls-remote --exit-code --heads origin "${BRANCH}" >/dev/null 2>&1; then
+            echo "::error::Branch ${BRANCH} already exists, from an abandoned release."
+            echo "::error::Reuse its pull request, or delete the branch and run this workflow again."
+            exit 1
+          fi
+          git switch -c "${BRANCH}"
+          git add package.json package-lock.json
+          git commit -m "${VERSION}"
+          git push origin "${BRANCH}"
+          {
+            echo "version=${VERSION}"
+            echo "tag=${TAG}"
+            echo "branch=${BRANCH}"
+          } >> "$GITHUB_OUTPUT"
+      - name: 📝 Job summary
+        env:
+          TAG: ${{ steps.bump.outputs.tag }}
+          BRANCH: ${{ steps.bump.outputs.branch }}
+          RELEASE_TYPE: ${{ inputs.release_type }}
+          REPO_URL: ${{ github.server_url }}/${{ github.repository }}
+        run: |
+          {
+            echo "### 📦 Release ${TAG} ready for review"
+            echo ""
+            echo "- Bump type: \`${RELEASE_TYPE}\`"
+            echo "- Branch: [\`${BRANCH}\`](${REPO_URL}/tree/${BRANCH})"
+            echo ""
+            echo "**[👉 Open the release pull request](${REPO_URL}/compare/master...${BRANCH}?expand=1)**"
+            echo ""
+            echo "The pull request has to be opened by a human: GitHub does not run the"
+            echo "required checks on a pull request opened by the \`GITHUB_TOKEN\`, so an"
+            echo "automatically opened one would stay blocked on them forever."
+            echo ""
+            echo "Once it is merged, the \`Create release tag\` workflow tags \`${TAG}\` on"
+            echo "master and publishes the \`gladysassistant/gladys-gateway-server:${TAG}\`"
+            echo "and \`latest\` Docker images."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/test-and-build.yml
+++ b/.github/workflows/test-and-build.yml
@@ -143,24 +143,3 @@ jobs:
           DOCKERHUB_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD }}
       - name: Docker build
         run: docker build -t gladysassistant/gladys-gateway-server:latest .
-  docker-build-and-push:
-    if: github.ref == 'refs/heads/master'
-    needs: test
-    name: Docker build and push
-    runs-on: ubuntu-latest
-    steps:
-      - name: ⬇️ Checkout code
-        uses: actions/checkout@v2
-      - name: Docker login
-        run: docker login -u="$DOCKERHUB_USER" -p="$DOCKERHUB_PASSWORD"
-        env:
-          DOCKERHUB_USER: ${{ secrets.DOCKERHUB_USER }}
-          DOCKERHUB_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD }}
-      - name: Docker build
-        # The MaxMind key is passed as a BuildKit secret: it is only mounted
-        # during the build step and never persisted in the image.
-        run: docker build --secret id=maxmind_license_key,env=MAX_MIND_LICENSE_KEY -t gladysassistant/gladys-gateway-server:latest .
-        env:
-          MAX_MIND_LICENSE_KEY: ${{ secrets.MAX_MIND_LICENSE_KEY }}
-      - name: Docker push
-        run: docker push gladysassistant/gladys-gateway-server:latest

--- a/README.md
+++ b/README.md
@@ -22,3 +22,13 @@ Thanks to everyone who supports this project 🙏
 This repository is open-source so the community can audit the code.
 
 There is no need to run this repo yourself, as if you want to access Gladys remotely without using Gladys Plus, you can just setup a VPN to your home network.
+
+## Release process
+
+Docker images are only published from a Git tag, so a release can be rolled back by deploying the previous `vX.Y.Z` image. Everything happens in the GitHub interface:
+
+1. Open the [Prepare release](../../actions/workflows/prepare-release.yml) workflow, click **Run workflow** on `master` and pick the bump type (`patch`, `minor` or `major`). It bumps the version in `package.json` on a `release/vX.Y.Z` branch and links to the pull request to open.
+2. Open and merge the release pull request once the checks are green.
+3. On merge, the **Create release tag** workflow tags `vX.Y.Z` on `master` and starts the **Release Docker image** workflow, which builds and pushes `gladysassistant/gladys-gateway-server:vX.Y.Z` and `latest` to Docker Hub.
+
+Merging a regular pull request to `master` no longer publishes an image.


### PR DESCRIPTION
## Why

Docker images were only published as `latest` on every push to `master`, which made rolling back a bad deploy impossible. Releases are now cut from a Git tag, entirely from the GitHub interface, mirroring the process used on the main Gladys repository.

## How it works

1. **Prepare release** (`prepare-release.yml`, manual "Run workflow" with `patch` / `minor` / `major`): bumps the version in `package.json` on a `release/vX.Y.Z` branch and links to the pull request to open in the job summary.
2. **Create release tag** (`create-release-tag.yml`): runs when `package.json` changes on `master`, creates the `vX.Y.Z` tag if it does not exist yet, and dispatches the Docker release workflow on the tag (a tag pushed with the `GITHUB_TOKEN` does not trigger `push: tags`).
3. **Release Docker image** (`docker-release-build.yml`): builds the image from the tag with the MaxMind BuildKit secret and pushes `gladysassistant/gladys-gateway-server:vX.Y.Z` and `latest` to Docker Hub. The `latest=auto` flavor skips pre-release tags.

Rolling back is then a matter of deploying the previous `vX.Y.Z` image.

## Behaviour change

- Merging a regular pull request to `master` **no longer pushes `latest`**: the `docker-build-and-push` job was removed from `test-and-build.yml`. Images are only published on release.
- The version field in `package.json` becomes a release trigger, so it should not be edited in unrelated pull requests.

## Notes

- No tag exists yet and the version is `1.0.0`, so the first release will be `v1.0.1` (patch) or `v1.1.0` (minor).
- The release pull request has to be opened by a human: GitHub does not run required checks on a pull request opened by the `GITHUB_TOKEN`.
- Uses the existing `DOCKERHUB_USER`, `DOCKERHUB_PASSWORD` and `MAX_MIND_LICENSE_KEY` secrets, nothing new to configure.
- A short "Release process" section was added to the README.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BRdDEZEEsXjs5xCNc5tp8K

---
_Generated by [Claude Code](https://claude.ai/code/session_01BRdDEZEEsXjs5xCNc5tp8K)_