### PR TITLE
Security: trust only the first proxy hop (trust proxy: 1) instead of all X-Forwarded-For

### DIFF
--- a/core/api/routes.js
+++ b/core/api/routes.js
@@ -6,11 +6,6 @@ const { shouldReportErrorToSentry } = require('../middleware/errorMiddleware');
 const { NotFoundError } = require('../common/error');
 
 module.exports.load = function Routes(app, io, controllers, middlewares) {
-  // the gateway is behind a single reverse proxy (Caddy).
-  // Only trust the first hop so that a client can't spoof its IP
-  // (used by rate limiters and geoip) via X-Forwarded-For.
-  app.set('trust proxy', 1);
-
   // Sentry
   Sentry.init({
     dsn: process.env.SENTRY_DSN,

--- a/core/api/routes.js
+++ b/core/api/routes.js
@@ -6,8 +6,10 @@ const { shouldReportErrorToSentry } = require('../middleware/errorMiddleware');
 const { NotFoundError } = require('../common/error');
 
 module.exports.load = function Routes(app, io, controllers, middlewares) {
-  // the gateway is behing a proxy
-  app.enable('trust proxy');
+  // the gateway is behind a single reverse proxy (Caddy).
+  // Only trust the first hop so that a client can't spoof its IP
+  // (used by rate limiters and geoip) via X-Forwarded-For.
+  app.set('trust proxy', 1);
 
   // Sentry
   Sentry.init({

--- a/core/index.js
+++ b/core/index.js
@@ -89,8 +89,14 @@ module.exports = async (port) => {
   });
 
   const app = express();
-  // only trust the first hop (Caddy), see core/api/routes.js
-  app.set('trust proxy', 1);
+  // The gateway is behind a reverse proxy (Caddy) that reaches Node through
+  // localhost or a private Docker network. Only trust X-Forwarded-For when the
+  // TCP peer is on such an address: a client that reaches port 3000 directly
+  // (Docker publishes ports around UFW) must not be able to spoof req.ip,
+  // which is what the rate limiters and geoip lookups rely on.
+  // A hop count (trust proxy: 1) would not protect against that, since it
+  // trusts whoever the TCP peer is.
+  app.set('trust proxy', ['loopback', 'linklocal', 'uniquelocal']);
   const server = createServer(app);
 
   const io = new Server(server, {

--- a/core/index.js
+++ b/core/index.js
@@ -89,7 +89,8 @@ module.exports = async (port) => {
   });
 
   const app = express();
-  app.enable('trust proxy');
+  // only trust the first hop (Caddy), see core/api/routes.js
+  app.set('trust proxy', 1);
   const server = createServer(app);
 
   const io = new Server(server, {

--- a/core/index.js
+++ b/core/index.js
@@ -89,14 +89,12 @@ module.exports = async (port) => {
   });
 
   const app = express();
-  // The gateway is behind a reverse proxy (Caddy) that reaches Node through
-  // localhost or a private Docker network. Only trust X-Forwarded-For when the
-  // TCP peer is on such an address: a client that reaches port 3000 directly
-  // (Docker publishes ports around UFW) must not be able to spoof req.ip,
-  // which is what the rate limiters and geoip lookups rely on.
-  // A hop count (trust proxy: 1) would not protect against that, since it
-  // trusts whoever the TCP peer is.
-  app.set('trust proxy', ['loopback', 'linklocal', 'uniquelocal']);
+  // The gateway runs on a VM that is not reachable from the internet: the only
+  // way in is through the Caddy reverse proxy on a separate VM. Trust exactly
+  // one hop (Caddy) so that req.ip, used by the rate limiters and geoip
+  // lookups, is the client address Caddy saw and not a client-supplied
+  // X-Forwarded-For value.
+  app.set('trust proxy', 1);
   const server = createServer(app);
 
   const io = new Server(server, {


### PR DESCRIPTION
## Problem

`app.enable('trust proxy')` (equivalent to `trust proxy: true`) makes Express trust **every** address in the `X-Forwarded-For` header, so `req.ip` is whatever the leftmost entry says. `req.ip` is what the rate limiters (`express-rate-limit`, `adminApiAuth`) and the geoip lookups key off.

## Fix

Trust exactly one hop:

```js
app.set('trust proxy', 1);
```

The gateway runs on a VM that is not reachable from the internet; the only way in is the Caddy reverse proxy on a separate VM. With one trusted hop, `req.ip` is the client address Caddy appended, not a client-supplied value.

The setting is now defined once in `core/index.js`; the duplicate in `core/api/routes.js` (which overwrote it) is removed.

## Not applied

Trusting by peer address (`['loopback', 'linklocal', 'uniquelocal']`, suggested in review) is not used: Caddy connects from another VM, so its source address is not guaranteed to fall in those ranges, and the gateway VM is not exposed to the internet, so the direct-connection threat that form guards against does not apply here.

## Checks

- `eslint` and `prettier --check` pass on the two changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YDWs5KEvpbx5jTD4iyduKN