### PR TITLE
Google Home: request a sync automatically when report state gets a 404 (device not found)

### DIFF
--- a/core/api/google/google.model.js
+++ b/core/api/google/google.model.js
@@ -9,9 +9,16 @@ const { ForbiddenError } = require('../../common/error');
 
 const GOOGLE_OAUTH_CODE_REDIS_PREFIX = `GOOGLE_OAUTH_CODE`;
 const GOOGLE_USERS_REDIS_PREFIX = 'google-users';
+const GOOGLE_REQUEST_SYNC_LOCK_REDIS_PREFIX = 'google-request-sync-lock';
+const GOOGLE_REQUEST_SYNC_LOCK_EXPIRY_IN_SECONDS = 60 * 60; // 1 hour
 const GOOGLE_CODE_EXPIRY_IN_SECONDS = 60 * 60;
 const JWT_AUDIENCE = 'google-home-oauth';
 const SCOPE = ['google-home'];
+
+const getGoogleErrorMessage = (e) => {
+  const message = get(e, 'response.data.error.message') || e.message;
+  return typeof message === 'string' ? message : JSON.stringify(message);
+};
 
 const cleanNullProperties = (obj) =>
   Object.entries(obj)
@@ -144,14 +151,44 @@ module.exports = function GoogleHomeModel(logger, db, redisClient, jwtService) {
       AND t_device.client_id = $2;
     `;
 
+  async function sendRequestSync(agentUserId) {
+    await homegraphClient.devices.requestSync({
+      requestBody: {
+        agentUserId,
+      },
+    });
+  }
+
   async function requestSync(instanceId) {
     const users = await db.query(getUsersWithGoogleActivatedQuery, [instanceId, GOOGLE_HOME_OAUTH_CLIENT_ID]);
     if (users.length > 0) {
-      await homegraphClient.devices.requestSync({
-        requestBody: {
-          agentUserId: users[0].account_id,
-        },
-      });
+      await sendRequestSync(users[0].account_id);
+    }
+  }
+
+  // Google answers 404 to a report state when the device no longer exists in the user's
+  // HomeGraph (removed or renamed on Google side). The instance keeps reporting it forever,
+  // so we ask Google to re-sync the device list, at most once per hour per account.
+  // The lock is taken with SET NX EX so concurrent 404s only trigger a single sync.
+  async function requestSyncAfterDeviceNotFound(agentUserId, userId, deviceIds) {
+    const lockKey = `${GOOGLE_REQUEST_SYNC_LOCK_REDIS_PREFIX}:${agentUserId}`;
+    const lockAcquired = await redisClient.set(lockKey, '1', {
+      NX: true,
+      EX: GOOGLE_REQUEST_SYNC_LOCK_EXPIRY_IN_SECONDS,
+    });
+    if (lockAcquired === null) {
+      logger.debug(
+        `GOOGLE_HOME_REPORT_STATE_DEVICE_NOT_FOUND user=${userId} devices=${deviceIds} (sync already requested recently)`,
+      );
+      return;
+    }
+    logger.info(`GOOGLE_HOME_REPORT_STATE_DEVICE_NOT_FOUND user=${userId} devices=${deviceIds}, requesting sync`);
+    try {
+      await sendRequestSync(agentUserId);
+    } catch (e) {
+      const status = get(e, 'response.status');
+      const message = getGoogleErrorMessage(e);
+      logger.warn(`GOOGLE_HOME_REQUEST_SYNC_ERROR user=${userId} status=${status} message=${message}`);
     }
   }
 
@@ -183,12 +220,14 @@ module.exports = function GoogleHomeModel(logger, db, redisClient, jwtService) {
         });
       } catch (e) {
         const status = get(e, 'response.status');
-        const message = get(e, 'response.data.error.message') || e.message;
-        const deviceIds = Object.keys(get(payloadCleaned, 'devices.states') || {});
+        const message = getGoogleErrorMessage(e);
+        const deviceIds = Object.keys(get(payloadCleaned, 'devices.states') || {}).join(',') || '—';
+        if (status === 404) {
+          await requestSyncAfterDeviceNotFound(users[0].account_id, users[0].id, deviceIds);
+          return;
+        }
         logger.warn(
-          `GOOGLE_HOME_REPORT_STATE_ERROR user=${users[0].id} status=${status} message=${message} devices=${
-            deviceIds.join(',') || '—'
-          }`,
+          `GOOGLE_HOME_REPORT_STATE_ERROR user=${users[0].id} status=${status} message=${message} devices=${deviceIds}`,
         );
       }
     }

--- a/core/api/google/google.model.js
+++ b/core/api/google/google.model.js
@@ -20,6 +20,11 @@ const getGoogleErrorMessage = (e) => {
   return typeof message === 'string' ? message : JSON.stringify(message);
 };
 
+// device ids come from the instance payload: strip control characters (CR, LF...)
+// so they cannot forge extra log lines
+// eslint-disable-next-line no-control-regex
+const sanitizeForLog = (str) => str.replace(/[\x00-\x1f\x7f]/g, ' ');
+
 const cleanNullProperties = (obj) =>
   Object.entries(obj)
     .map(([k, v]) => [k, v && typeof v === 'object' ? cleanNullProperties(v) : v])
@@ -151,10 +156,13 @@ module.exports = function GoogleHomeModel(logger, db, redisClient, jwtService) {
       AND t_device.client_id = $2;
     `;
 
-  async function sendRequestSync(agentUserId) {
+  // async: when true, Google queues the sync and answers immediately. It allows concurrent
+  // Request Sync for the same agentUserId (a synchronous one returns 429 in that case).
+  async function sendRequestSync(agentUserId, { async = false } = {}) {
     await homegraphClient.devices.requestSync({
       requestBody: {
         agentUserId,
+        ...(async ? { async: true } : {}),
       },
     });
   }
@@ -172,10 +180,18 @@ module.exports = function GoogleHomeModel(logger, db, redisClient, jwtService) {
   // The lock is taken with SET NX EX so concurrent 404s only trigger a single sync.
   async function requestSyncAfterDeviceNotFound(agentUserId, userId, deviceIds) {
     const lockKey = `${GOOGLE_REQUEST_SYNC_LOCK_REDIS_PREFIX}:${agentUserId}`;
-    const lockAcquired = await redisClient.set(lockKey, '1', {
-      NX: true,
-      EX: GOOGLE_REQUEST_SYNC_LOCK_EXPIRY_IN_SECONDS,
-    });
+    let lockAcquired;
+    try {
+      lockAcquired = await redisClient.set(lockKey, '1', {
+        NX: true,
+        EX: GOOGLE_REQUEST_SYNC_LOCK_EXPIRY_IN_SECONDS,
+      });
+    } catch (e) {
+      // Redis unavailable: don't turn a handled 404 into a failed report state,
+      // and don't sync without the lock (it would spam Google)
+      logger.warn(`GOOGLE_HOME_REQUEST_SYNC_LOCK_ERROR user=${userId} message=${e.message}`);
+      return;
+    }
     if (lockAcquired === null) {
       logger.debug(
         `GOOGLE_HOME_REPORT_STATE_DEVICE_NOT_FOUND user=${userId} devices=${deviceIds} (sync already requested recently)`,
@@ -184,7 +200,9 @@ module.exports = function GoogleHomeModel(logger, db, redisClient, jwtService) {
     }
     logger.info(`GOOGLE_HOME_REPORT_STATE_DEVICE_NOT_FOUND user=${userId} devices=${deviceIds}, requesting sync`);
     try {
-      await sendRequestSync(agentUserId);
+      // async so this recovery sync neither collides with an instance-initiated
+      // Request Sync (429) nor makes the report state wait for a full SYNC round-trip
+      await sendRequestSync(agentUserId, { async: true });
     } catch (e) {
       const status = get(e, 'response.status');
       const message = getGoogleErrorMessage(e);
@@ -221,7 +239,7 @@ module.exports = function GoogleHomeModel(logger, db, redisClient, jwtService) {
       } catch (e) {
         const status = get(e, 'response.status');
         const message = getGoogleErrorMessage(e);
-        const deviceIds = Object.keys(get(payloadCleaned, 'devices.states') || {}).join(',') || '—';
+        const deviceIds = sanitizeForLog(Object.keys(get(payloadCleaned, 'devices.states') || {}).join(',')) || '—';
         if (status === 404) {
           await requestSyncAfterDeviceNotFound(users[0].account_id, users[0].id, deviceIds);
           return;

--- a/test/core/api/google/google.controller.test.js
+++ b/test/core/api/google/google.controller.test.js
@@ -436,7 +436,8 @@ describe('POST /google/report_state', () => {
   it('should report a new state, have a 404 (device not found google side) and request a sync once', async () => {
     nock('https://www.googleapis.com:443', { encodedQueryParams: true })
       .post('/oauth2/v4/token', () => true)
-      .times(4)
+      // 2 report states + 1 request sync
+      .times(3)
       .reply(200, {
         accessToken: 'toto',
       });
@@ -454,9 +455,9 @@ describe('POST /google/report_state', () => {
           status: 'NOT_FOUND',
         },
       });
-    // the first 404 triggers a request sync
+    // the first 404 triggers an async request sync
     const firstRequestSyncScope = nock('https://homegraph.googleapis.com:443', { encodedQueryParams: true })
-      .post('/v1/devices:requestSync', { agentUserId: 'b2d23f66-487d-493f-8acb-9c8adb400def' })
+      .post('/v1/devices:requestSync', { agentUserId: 'b2d23f66-487d-493f-8acb-9c8adb400def', async: true })
       .reply(200, {
         status: 200,
       });
@@ -480,11 +481,12 @@ describe('POST /google/report_state', () => {
     expect(response.body).to.deep.equal({ status: 200 });
     expect(firstRequestSyncScope.isDone()).to.equal(true);
     // a second 404 within the hour must not request another sync (Redis lock)
-    const secondRequestSyncScope = nock('https://homegraph.googleapis.com:443', { encodedQueryParams: true })
-      .post('/v1/devices:requestSync', { agentUserId: 'b2d23f66-487d-493f-8acb-9c8adb400def' })
-      .reply(200, {
-        status: 200,
-      });
+    const secondRequestSyncInterceptor = nock('https://homegraph.googleapis.com:443', {
+      encodedQueryParams: true,
+    }).post('/v1/devices:requestSync', () => true);
+    const secondRequestSyncScope = secondRequestSyncInterceptor.reply(200, {
+      status: 200,
+    });
     const response2 = await request(TEST_BACKEND_APP)
       .post('/google/report_state')
       .send(reportStatePayload)
@@ -495,7 +497,9 @@ describe('POST /google/report_state', () => {
     expect(response2.body).to.deep.equal({ status: 200 });
     expect(reportStateScope.isDone()).to.equal(true);
     expect(secondRequestSyncScope.isDone()).to.equal(false);
-    nock.cleanAll();
+    // only remove our own pending interceptor: nock.cleanAll() would also drop the
+    // persistent nocks from test/tasks/nock.js used by later tests
+    nock.removeInterceptor(secondRequestSyncInterceptor);
   });
   it('should report a new state, have a 404 and not crash if the request sync fails', async () => {
     nock('https://www.googleapis.com:443', { encodedQueryParams: true })
@@ -514,7 +518,7 @@ describe('POST /google/report_state', () => {
         },
       });
     const requestSyncScope = nock('https://homegraph.googleapis.com:443', { encodedQueryParams: true })
-      .post('/v1/devices:requestSync', { agentUserId: 'b2d23f66-487d-493f-8acb-9c8adb400def' })
+      .post('/v1/devices:requestSync', { agentUserId: 'b2d23f66-487d-493f-8acb-9c8adb400def', async: true })
       .reply(500, {
         error: {
           code: 500,

--- a/test/core/api/google/google.controller.test.js
+++ b/test/core/api/google/google.controller.test.js
@@ -433,23 +433,93 @@ describe('POST /google/report_state', () => {
       .expect(200);
     expect(response2.body).to.deep.equal({ status: 200 });
   });
-  it('should report a new state and have a 404 (device not found google side)', async () => {
+  it('should report a new state, have a 404 (device not found google side) and request a sync once', async () => {
     nock('https://www.googleapis.com:443', { encodedQueryParams: true })
       .post('/oauth2/v4/token', () => true)
+      .times(4)
+      .reply(200, {
+        accessToken: 'toto',
+      });
+    const reportStateScope = nock('https://homegraph.googleapis.com:443', { encodedQueryParams: true })
+      .post('/v1/devices:reportStateAndNotification', (body) => {
+        const validAgentUserId = body.agentUserId === 'b2d23f66-487d-493f-8acb-9c8adb400def';
+        const payloadValid = get(body, 'payload.devices.states.light-123.on') === true;
+        return validAgentUserId && payloadValid;
+      })
+      .times(2)
+      .reply(404, {
+        error: {
+          code: 404,
+          message: 'Device ID cannot be found.',
+          status: 'NOT_FOUND',
+        },
+      });
+    // the first 404 triggers a request sync
+    const firstRequestSyncScope = nock('https://homegraph.googleapis.com:443', { encodedQueryParams: true })
+      .post('/v1/devices:requestSync', { agentUserId: 'b2d23f66-487d-493f-8acb-9c8adb400def' })
+      .reply(200, {
+        status: 200,
+      });
+    const reportStatePayload = {
+      devices: {
+        states: {
+          'light-123': {
+            on: true,
+            online: true,
+          },
+        },
+      },
+    };
+    const response = await request(TEST_BACKEND_APP)
+      .post('/google/report_state')
+      .send(reportStatePayload)
+      .set('Accept', 'application/json')
+      .set('Authorization', configTest.jwtAccessTokenInstance)
+      .expect('Content-Type', /json/)
+      .expect(200);
+    expect(response.body).to.deep.equal({ status: 200 });
+    expect(firstRequestSyncScope.isDone()).to.equal(true);
+    // a second 404 within the hour must not request another sync (Redis lock)
+    const secondRequestSyncScope = nock('https://homegraph.googleapis.com:443', { encodedQueryParams: true })
+      .post('/v1/devices:requestSync', { agentUserId: 'b2d23f66-487d-493f-8acb-9c8adb400def' })
+      .reply(200, {
+        status: 200,
+      });
+    const response2 = await request(TEST_BACKEND_APP)
+      .post('/google/report_state')
+      .send(reportStatePayload)
+      .set('Accept', 'application/json')
+      .set('Authorization', configTest.jwtAccessTokenInstance)
+      .expect('Content-Type', /json/)
+      .expect(200);
+    expect(response2.body).to.deep.equal({ status: 200 });
+    expect(reportStateScope.isDone()).to.equal(true);
+    expect(secondRequestSyncScope.isDone()).to.equal(false);
+    nock.cleanAll();
+  });
+  it('should report a new state, have a 404 and not crash if the request sync fails', async () => {
+    nock('https://www.googleapis.com:443', { encodedQueryParams: true })
+      .post('/oauth2/v4/token', () => true)
+      .times(2)
       .reply(200, {
         accessToken: 'toto',
       });
     nock('https://homegraph.googleapis.com:443', { encodedQueryParams: true })
-      .post('/v1/devices:reportStateAndNotification', (body) => {
-        const validAgentUserId = body.agentUserId === 'b2d23f66-487d-493f-8acb-9c8adb400def';
-        const payloadValid = get(body, 'payload.devices.states.light-123.on') === true;
-        const brightnessValid = get(body, 'payload.devices.states.light-123.brightness') === undefined;
-        const spectrumRgbValid = get(body, 'payload.devices.states.light-123.color.spectrumRgb') === undefined;
-        const temperatureKValid = get(body, 'payload.devices.states.light-123.color.temperatureK') === 2000;
-        return validAgentUserId && payloadValid && brightnessValid && spectrumRgbValid && temperatureKValid;
-      })
+      .post('/v1/devices:reportStateAndNotification', () => true)
       .reply(404, {
-        status: 404,
+        error: {
+          code: 404,
+          message: 'Device ID cannot be found.',
+          status: 'NOT_FOUND',
+        },
+      });
+    const requestSyncScope = nock('https://homegraph.googleapis.com:443', { encodedQueryParams: true })
+      .post('/v1/devices:requestSync', { agentUserId: 'b2d23f66-487d-493f-8acb-9c8adb400def' })
+      .reply(500, {
+        error: {
+          code: 500,
+          message: 'Internal error',
+        },
       });
     const response = await request(TEST_BACKEND_APP)
       .post('/google/report_state')
@@ -459,11 +529,6 @@ describe('POST /google/report_state', () => {
             'light-123': {
               on: true,
               online: true,
-              brightness: null,
-              color: {
-                spectrumRgb: null,
-                temperatureK: 2000,
-              },
             },
           },
         },
@@ -473,6 +538,7 @@ describe('POST /google/report_state', () => {
       .expect('Content-Type', /json/)
       .expect(200);
     expect(response.body).to.deep.equal({ status: 200 });
+    expect(requestSyncScope.isDone()).to.equal(true);
   });
   it('should report a new state and have a 500 (error on google side)', async () => {
     nock('https://www.googleapis.com:443', { encodedQueryParams: true })


### PR DESCRIPTION
## Problem

Production logs are flooded with lines like:

```
<warn> google.model.js:182 (Object.reportState) GOOGLE_HOME_REPORT_STATE_ERROR user=… status=404 message=Device ID cannot be found. This is usually an indication that the device may have been removed. Send a Request Sync to re-sync the device in Google. devices=prise-tv
```

Since #195 every error returned by `reportStateAndNotification` is logged as `warn`, 404 included (before that, 404s were explicitly ignored). A 404 means the device no longer exists in the user's HomeGraph (removed or renamed on Google side), but the Gladys instance keeps reporting its state on every change, so the same user/device pairs repeat indefinitely. None of the recent fixes touched this code path.

## Fix

- On a 404 from report state, the gateway now sends a **Request Sync** to Google for that account so the device list is refreshed, as Google's own error message suggests.
- A **Redis lock** (`SET NX EX`, 1 hour, keyed by `agentUserId`) guarantees at most one automatic sync per account per hour, even with concurrent 404s.
- Logging: the 404 that triggers a sync is logged once as `info` (`GOOGLE_HOME_REPORT_STATE_DEVICE_NOT_FOUND … requesting sync`), following 404s within the hour as `debug`. A failing request sync is logged as `warn` (`GOOGLE_HOME_REQUEST_SYNC_ERROR`). All other statuses keep the existing `warn`.
- The existing `requestSync(instanceId)` now shares a small `sendRequestSync(agentUserId)` helper with the new path.
- Non-string Google error messages are stringified so the warn never prints `message=[object Object]`.

## Tests

- `POST /google/report_state` 404 test now asserts that a Request Sync is sent once, and that a second 404 does **not** trigger another one (lock).
- New test: a 404 followed by a failing Request Sync still returns 200 to the instance.

Ran locally: `prettier-check`, `eslint`, and the Google controller tests (17 passing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01De8CtUyH5CQ4gCT2HkqLvQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01De8CtUyH5CQ4gCT2HkqLvQ)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling when Google reports that a device cannot be found.
  * Automatically requests a device synchronization after a missing-device error, with a limit of once per account per hour.
  * Report-state requests continue returning successfully even if synchronization fails.
  * Simplified report-state validation for supported device properties.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->