### PR TITLE
Google Home: retry report state with backoff on transient HomeGraph errors (503, 500, 429)

### DIFF
--- a/core/api/google/google.model.js
+++ b/core/api/google/google.model.js
@@ -2,6 +2,7 @@ const Promise = require('bluebird');
 const crypto = require('crypto');
 const jwt = require('jsonwebtoken');
 const get = require('get-value');
+const retry = require('async-retry');
 const { homegraph, auth } = require('@googleapis/homegraph');
 const randomBytes = Promise.promisify(require('crypto').randomBytes);
 const { ForbiddenError } = require('../../common/error');
@@ -13,10 +14,27 @@ const GOOGLE_REQUEST_SYNC_LOCK_EXPIRY_IN_SECONDS = 60 * 60; // 1 hour
 const GOOGLE_CODE_EXPIRY_IN_SECONDS = 60 * 60;
 const JWT_AUDIENCE = 'google-home-oauth';
 const SCOPE = ['google-home'];
+// HomeGraph regularly answers a report state with a transient error (503 "The service is
+// currently unavailable", 500, 429...). The instance never resends a state, so a lost report
+// leaves Google with a stale device: retry with an exponential backoff (500ms, then 1s)
+// before giving up. Kept short because the instance is waiting for our HTTP answer.
+const GOOGLE_REPORT_STATE_RETRY_CONFIG = {
+  retries: 2,
+  minTimeout: 500,
+  factor: 2,
+  randomize: false,
+};
 
 const getGoogleErrorMessage = (e) => {
   const message = get(e, 'response.data.error.message') || e.message;
   return typeof message === 'string' ? message : JSON.stringify(message);
+};
+
+// only server-side / rate-limit errors are worth retrying: a 4xx (404 device not found,
+// 400 invalid payload, 403...) will fail the same way on the next attempt
+const isTransientGoogleError = (e) => {
+  const status = get(e, 'response.status');
+  return status === 429 || (status >= 500 && status <= 599);
 };
 
 // device ids come from the instance payload: strip control characters (CR, LF...)
@@ -232,20 +250,44 @@ module.exports = function GoogleHomeModel(logger, db, redisClient, jwtService) {
         agentUserId: users[0].account_id,
         payload: payloadCleaned,
       };
+      const deviceIds = sanitizeForLog(Object.keys(get(payloadCleaned, 'devices.states') || {}).join(',')) || '—';
       try {
-        await homegraphClient.devices.reportStateAndNotification({
-          requestBody,
-        });
+        await retry(
+          async (bail) => {
+            try {
+              await homegraphClient.devices.reportStateAndNotification({
+                requestBody,
+              });
+            } catch (e) {
+              if (!isTransientGoogleError(e)) {
+                bail(e);
+                return;
+              }
+              throw e;
+            }
+          },
+          {
+            ...GOOGLE_REPORT_STATE_RETRY_CONFIG,
+            onRetry: (e, attempt) => {
+              logger.debug(
+                `GOOGLE_HOME_REPORT_STATE_RETRY user=${users[0].id} status=${get(
+                  e,
+                  'response.status',
+                )} attempt=${attempt} devices=${deviceIds}`,
+              );
+            },
+          },
+        );
       } catch (e) {
         const status = get(e, 'response.status');
         const message = getGoogleErrorMessage(e);
-        const deviceIds = sanitizeForLog(Object.keys(get(payloadCleaned, 'devices.states') || {}).join(',')) || '—';
         if (status === 404) {
           await requestSyncAfterDeviceNotFound(users[0].account_id, users[0].id, deviceIds);
           return;
         }
+        const retried = isTransientGoogleError(e) ? ` (after ${GOOGLE_REPORT_STATE_RETRY_CONFIG.retries} retries)` : '';
         logger.warn(
-          `GOOGLE_HOME_REPORT_STATE_ERROR user=${users[0].id} status=${status} message=${message} devices=${deviceIds}`,
+          `GOOGLE_HOME_REPORT_STATE_ERROR user=${users[0].id} status=${status} message=${message} devices=${deviceIds}${retried}`,
         );
       }
     }

--- a/core/api/google/google.model.js
+++ b/core/api/google/google.model.js
@@ -16,24 +16,38 @@ const JWT_AUDIENCE = 'google-home-oauth';
 const SCOPE = ['google-home'];
 // HomeGraph regularly answers a report state with a transient error (503 "The service is
 // currently unavailable", 500, 429...). The instance never resends a state, so a lost report
-// leaves Google with a stale device: retry with an exponential backoff (500ms, then 1s)
-// before giving up. Kept short because the instance is waiting for our HTTP answer.
+// leaves Google with a stale device: retry with an exponential backoff (500ms-1s, then 1s-2s,
+// jittered so every instance hit by the same Google blip does not retry in lockstep) before
+// giving up. Kept short because the instance is waiting for our HTTP answer.
 const GOOGLE_REPORT_STATE_RETRY_CONFIG = {
   retries: 2,
   minTimeout: 500,
   factor: 2,
-  randomize: false,
 };
+// connection-level failures reported by gaxios (no HTTP response, `code` copied from the
+// underlying socket error): as transient as a 503
+const NETWORK_ERROR_CODES = [
+  'ECONNRESET',
+  'ECONNREFUSED',
+  'ECONNABORTED',
+  'ETIMEDOUT',
+  'EPIPE',
+  'EAI_AGAIN',
+  'ENOTFOUND',
+];
 
 const getGoogleErrorMessage = (e) => {
   const message = get(e, 'response.data.error.message') || e.message;
   return typeof message === 'string' ? message : JSON.stringify(message);
 };
 
-// only server-side / rate-limit errors are worth retrying: a 4xx (404 device not found,
-// 400 invalid payload, 403...) will fail the same way on the next attempt
+// only server-side / rate-limit / network errors are worth retrying: a 4xx (404 device not
+// found, 400 invalid payload, 403...) or a programming error will fail the same way next time
 const isTransientGoogleError = (e) => {
   const status = get(e, 'response.status');
+  if (status === undefined) {
+    return NETWORK_ERROR_CODES.includes(e.code);
+  }
   return status === 429 || (status >= 500 && status <= 599);
 };
 
@@ -270,16 +284,15 @@ module.exports = function GoogleHomeModel(logger, db, redisClient, jwtService) {
             ...GOOGLE_REPORT_STATE_RETRY_CONFIG,
             onRetry: (e, attempt) => {
               logger.debug(
-                `GOOGLE_HOME_REPORT_STATE_RETRY user=${users[0].id} status=${get(
-                  e,
-                  'response.status',
-                )} attempt=${attempt} devices=${deviceIds}`,
+                `GOOGLE_HOME_REPORT_STATE_RETRY user=${users[0].id} status=${
+                  get(e, 'response.status') || e.code
+                } attempt=${attempt} devices=${deviceIds}`,
               );
             },
           },
         );
       } catch (e) {
-        const status = get(e, 'response.status');
+        const status = get(e, 'response.status') || e.code;
         const message = getGoogleErrorMessage(e);
         if (status === 404) {
           await requestSyncAfterDeviceNotFound(users[0].account_id, users[0].id, deviceIds);

--- a/test/core/api/google/google.controller.test.js
+++ b/test/core/api/google/google.controller.test.js
@@ -545,7 +545,7 @@ describe('POST /google/report_state', () => {
     expect(requestSyncScope.isDone()).to.equal(true);
   });
   it('should report a new state, have a 503 (transient error on google side) and retry until it succeeds', async function Test() {
-    // 2 retries with a 500ms then 1s backoff
+    // 2 retries with a jittered backoff (up to 1s then 2s)
     this.timeout(5000);
     nock('https://www.googleapis.com:443', { encodedQueryParams: true })
       .post('/oauth2/v4/token', () => true)
@@ -598,7 +598,7 @@ describe('POST /google/report_state', () => {
     expect(successScope.isDone()).to.equal(true);
   });
   it('should report a new state, have a 503 on every attempt and give up after 2 retries', async function Test() {
-    // 2 retries with a 500ms then 1s backoff
+    // 2 retries with a jittered backoff (up to 1s then 2s)
     this.timeout(5000);
     nock('https://www.googleapis.com:443', { encodedQueryParams: true })
       .post('/oauth2/v4/token', () => true)
@@ -646,6 +646,46 @@ describe('POST /google/report_state', () => {
     expect(requestSyncScope.isDone()).to.equal(false);
     nock.removeInterceptor(requestSyncInterceptor);
   });
+  it('should report a new state, have a connection error (no HTTP response) and retry', async function Test() {
+    this.timeout(5000);
+    nock('https://www.googleapis.com:443', { encodedQueryParams: true })
+      .post('/oauth2/v4/token', () => true)
+      .times(2)
+      .reply(200, {
+        accessToken: 'toto',
+      });
+    const failingScope = nock('https://homegraph.googleapis.com:443', { encodedQueryParams: true })
+      .post('/v1/devices:reportStateAndNotification', () => true)
+      .replyWithError({ code: 'ECONNRESET', message: 'socket hang up' });
+    const successScope = nock('https://homegraph.googleapis.com:443', { encodedQueryParams: true })
+      .post('/v1/devices:reportStateAndNotification', (body) => {
+        const validAgentUserId = body.agentUserId === 'b2d23f66-487d-493f-8acb-9c8adb400def';
+        const payloadValid = get(body, 'payload.devices.states.light-123.on') === true;
+        return validAgentUserId && payloadValid;
+      })
+      .reply(200, {
+        status: 200,
+      });
+    const response = await request(TEST_BACKEND_APP)
+      .post('/google/report_state')
+      .send({
+        devices: {
+          states: {
+            'light-123': {
+              on: true,
+              online: true,
+            },
+          },
+        },
+      })
+      .set('Accept', 'application/json')
+      .set('Authorization', configTest.jwtAccessTokenInstance)
+      .expect('Content-Type', /json/)
+      .expect(200);
+    expect(response.body).to.deep.equal({ status: 200 });
+    expect(failingScope.isDone()).to.equal(true);
+    expect(successScope.isDone()).to.equal(true);
+  });
   it('should report a new state, have a 400 (invalid payload) and not retry', async () => {
     nock('https://www.googleapis.com:443', { encodedQueryParams: true })
       .post('/oauth2/v4/token', () => true)
@@ -689,7 +729,7 @@ describe('POST /google/report_state', () => {
     nock.removeInterceptor(retryInterceptor);
   });
   it('should report a new state and have a 500 (error on google side)', async function Test() {
-    // a 500 is retried twice (500ms then 1s backoff)
+    // a 500 is retried twice (jittered backoff, up to 1s then 2s)
     this.timeout(5000);
     nock('https://www.googleapis.com:443', { encodedQueryParams: true })
       .post('/oauth2/v4/token', () => true)

--- a/test/core/api/google/google.controller.test.js
+++ b/test/core/api/google/google.controller.test.js
@@ -544,13 +544,160 @@ describe('POST /google/report_state', () => {
     expect(response.body).to.deep.equal({ status: 200 });
     expect(requestSyncScope.isDone()).to.equal(true);
   });
-  it('should report a new state and have a 500 (error on google side)', async () => {
+  it('should report a new state, have a 503 (transient error on google side) and retry until it succeeds', async function Test() {
+    // 2 retries with a 500ms then 1s backoff
+    this.timeout(5000);
+    nock('https://www.googleapis.com:443', { encodedQueryParams: true })
+      .post('/oauth2/v4/token', () => true)
+      // 1 attempt + 2 retries: the mocked token is not cached, so one token call per attempt
+      .times(3)
+      .reply(200, {
+        accessToken: 'toto',
+      });
+    const failingScope = nock('https://homegraph.googleapis.com:443', { encodedQueryParams: true })
+      .post('/v1/devices:reportStateAndNotification', (body) => {
+        const validAgentUserId = body.agentUserId === 'b2d23f66-487d-493f-8acb-9c8adb400def';
+        const payloadValid = get(body, 'payload.devices.states.light-123.on') === true;
+        return validAgentUserId && payloadValid;
+      })
+      .times(2)
+      .reply(503, {
+        error: {
+          code: 503,
+          message: 'The service is currently unavailable.',
+          status: 'UNAVAILABLE',
+        },
+      });
+    const successScope = nock('https://homegraph.googleapis.com:443', { encodedQueryParams: true })
+      .post('/v1/devices:reportStateAndNotification', (body) => {
+        const validAgentUserId = body.agentUserId === 'b2d23f66-487d-493f-8acb-9c8adb400def';
+        const payloadValid = get(body, 'payload.devices.states.light-123.on') === true;
+        return validAgentUserId && payloadValid;
+      })
+      .reply(200, {
+        status: 200,
+      });
+    const response = await request(TEST_BACKEND_APP)
+      .post('/google/report_state')
+      .send({
+        devices: {
+          states: {
+            'light-123': {
+              on: true,
+              online: true,
+            },
+          },
+        },
+      })
+      .set('Accept', 'application/json')
+      .set('Authorization', configTest.jwtAccessTokenInstance)
+      .expect('Content-Type', /json/)
+      .expect(200);
+    expect(response.body).to.deep.equal({ status: 200 });
+    expect(failingScope.isDone()).to.equal(true);
+    expect(successScope.isDone()).to.equal(true);
+  });
+  it('should report a new state, have a 503 on every attempt and give up after 2 retries', async function Test() {
+    // 2 retries with a 500ms then 1s backoff
+    this.timeout(5000);
+    nock('https://www.googleapis.com:443', { encodedQueryParams: true })
+      .post('/oauth2/v4/token', () => true)
+      // 1 attempt + 2 retries: the mocked token is not cached, so one token call per attempt
+      .times(3)
+      .reply(200, {
+        accessToken: 'toto',
+      });
+    // 1 attempt + 2 retries: a 4th call would fail on nock (no interceptor left)
+    const reportStateScope = nock('https://homegraph.googleapis.com:443', { encodedQueryParams: true })
+      .post('/v1/devices:reportStateAndNotification', () => true)
+      .times(3)
+      .reply(503, {
+        error: {
+          code: 503,
+          message: 'The service is currently unavailable.',
+          status: 'UNAVAILABLE',
+        },
+      });
+    const requestSyncInterceptor = nock('https://homegraph.googleapis.com:443', {
+      encodedQueryParams: true,
+    }).post('/v1/devices:requestSync', () => true);
+    const requestSyncScope = requestSyncInterceptor.reply(200, {
+      status: 200,
+    });
+    const response = await request(TEST_BACKEND_APP)
+      .post('/google/report_state')
+      .send({
+        devices: {
+          states: {
+            'light-123': {
+              on: true,
+              online: true,
+            },
+          },
+        },
+      })
+      .set('Accept', 'application/json')
+      .set('Authorization', configTest.jwtAccessTokenInstance)
+      .expect('Content-Type', /json/)
+      .expect(200);
+    expect(response.body).to.deep.equal({ status: 200 });
+    expect(reportStateScope.isDone()).to.equal(true);
+    // a 503 is not a "device not found": no sync must be requested
+    expect(requestSyncScope.isDone()).to.equal(false);
+    nock.removeInterceptor(requestSyncInterceptor);
+  });
+  it('should report a new state, have a 400 (invalid payload) and not retry', async () => {
     nock('https://www.googleapis.com:443', { encodedQueryParams: true })
       .post('/oauth2/v4/token', () => true)
       .reply(200, {
         accessToken: 'toto',
       });
-    nock('https://homegraph.googleapis.com:443', { encodedQueryParams: true })
+    const reportStateScope = nock('https://homegraph.googleapis.com:443', { encodedQueryParams: true })
+      .post('/v1/devices:reportStateAndNotification', () => true)
+      .reply(400, {
+        error: {
+          code: 400,
+          message: 'Request contains an invalid argument.',
+          status: 'INVALID_ARGUMENT',
+        },
+      });
+    const retryInterceptor = nock('https://homegraph.googleapis.com:443', {
+      encodedQueryParams: true,
+    }).post('/v1/devices:reportStateAndNotification', () => true);
+    const retryScope = retryInterceptor.reply(200, {
+      status: 200,
+    });
+    const response = await request(TEST_BACKEND_APP)
+      .post('/google/report_state')
+      .send({
+        devices: {
+          states: {
+            'light-123': {
+              on: true,
+              online: true,
+            },
+          },
+        },
+      })
+      .set('Accept', 'application/json')
+      .set('Authorization', configTest.jwtAccessTokenInstance)
+      .expect('Content-Type', /json/)
+      .expect(200);
+    expect(response.body).to.deep.equal({ status: 200 });
+    expect(reportStateScope.isDone()).to.equal(true);
+    expect(retryScope.isDone()).to.equal(false);
+    nock.removeInterceptor(retryInterceptor);
+  });
+  it('should report a new state and have a 500 (error on google side)', async function Test() {
+    // a 500 is retried twice (500ms then 1s backoff)
+    this.timeout(5000);
+    nock('https://www.googleapis.com:443', { encodedQueryParams: true })
+      .post('/oauth2/v4/token', () => true)
+      .times(3)
+      .reply(200, {
+        accessToken: 'toto',
+      });
+    const reportStateScope = nock('https://homegraph.googleapis.com:443', { encodedQueryParams: true })
       .post('/v1/devices:reportStateAndNotification', (body) => {
         const validAgentUserId = body.agentUserId === 'b2d23f66-487d-493f-8acb-9c8adb400def';
         const payloadValid = get(body, 'payload.devices.states.light-123.on') === true;
@@ -559,6 +706,7 @@ describe('POST /google/report_state', () => {
         const temperatureKValid = get(body, 'payload.devices.states.light-123.color.temperatureK') === 2000;
         return validAgentUserId && payloadValid && brightnessValid && spectrumRgbValid && temperatureKValid;
       })
+      .times(3)
       .reply(500, {
         status: 500,
       });
@@ -584,5 +732,6 @@ describe('POST /google/report_state', () => {
       .expect('Content-Type', /json/)
       .expect(200);
     expect(response.body).to.deep.equal({ status: 200 });
+    expect(reportStateScope.isDone()).to.equal(true);
   });
 });


### PR DESCRIPTION
## Context

The logs show many warnings like:

```
GOOGLE_HOME_REPORT_STATE_ERROR user=… status=503 message=The service is currently unavailable. devices=prise-tv
```

A 503 `UNAVAILABLE` from HomeGraph is a transient server-side error. Until now the report state was sent exactly once: gaxios (used by `@googleapis/homegraph`) only retries GET/HEAD/PUT/OPTIONS/DELETE by default, never a POST. The state was then lost, since the instance does not resend it: Google kept a stale device state and the warning was logged on every occurrence.

## Changes

- `reportState` now retries up to 2 times with an exponential backoff (500ms, then 1s) on 429 / 5xx answers, using `async-retry` like the backup and tempo models. The delays are kept short because the instance is waiting for the gateway's HTTP answer.
- 4xx answers are not retried: a 404 still goes through the request-sync recovery added in #212, a 400 would fail the same way on the next attempt.
- Each retry is logged at debug level (`GOOGLE_HOME_REPORT_STATE_RETRY`), and the remaining warning ends with `(after 2 retries)` so a persistent 503 can be told apart from a blip.

## Tests

- 503 twice then 200: the state is reported, no warning.
- 503 on every attempt: gives up after 3 calls, no request sync is triggered.
- 400: not retried.
- The existing 500 test now covers the retries.

Run locally with Postgres + Redis: prettier, eslint and the Google/Alexa suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EvocCeWkuqq3aNEyeuy32b

---
_Generated by [Claude Code](https://claude.ai/code/session_01EvocCeWkuqq3aNEyeuy32b)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when reporting device states to Google Home by automatically retrying temporary service errors.
  * Stops retrying immediately for invalid requests and other non-temporary errors.
  * Provides clearer error information when all retry attempts fail.

* **Tests**
  * Added coverage for successful retries, exhausted retry attempts, and non-retryable errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->