### PR TITLE
Ecowatt: serve stale data, single refresh lock, slower RTE backoff

### DIFF
--- a/core/api/ecowatt/ecowatt.controller.js
+++ b/core/api/ecowatt/ecowatt.controller.js
@@ -6,7 +6,7 @@ module.exports = function EcowattController(logger, ecowattModel) {
    */
   async function getEcowattSignals(req, res) {
     logger.info(`Ecowatt.getEcowattSignals`);
-    const response = await ecowattModel.getDataWithRetry();
+    const response = await ecowattModel.getDataLiveOrFromCache();
     const cachePeriodInSecond = 60 * 60;
     res.set('Cache-control', `public, max-age=${cachePeriodInSecond}`);
     res.json(response);

--- a/core/api/ecowatt/ecowatt.model.js
+++ b/core/api/ecowatt/ecowatt.model.js
@@ -1,14 +1,37 @@
 const axios = require('axios');
 const retry = require('async-retry');
 
+// Fresh copy of the RTE data, refreshed once it expires
 const ECOWATT_CACHE_KEY = 'ecowatt:data:v4';
 const ECOWATT_REDIS_EXPIRY_IN_SECONDS = 60 * 60; // 1 hour
+// Last data successfully fetched from RTE, kept without TTL so it can still be
+// served when RTE fails (429 / 500) instead of failing the request
+const ECOWATT_STALE_CACHE_KEY = 'ecowatt:data:v4:stale';
+// Lock taken with SET NX EX so only one gateway instance refreshes the data
+// from RTE when the cache expires, instead of every instance at the same time
+const ECOWATT_REFRESH_LOCK_KEY = 'ecowatt:refresh-lock:v4';
+// Must cover the whole retry sequence (see getDataLiveWithRetry). A failed refresh
+// keeps the lock until it expires, which acts as a cooldown before calling RTE again
+const ECOWATT_REFRESH_LOCK_EXPIRY_IN_SECONDS = 60;
+// An instance without any data (fresh or stale) while another one is refreshing
+// polls the cache instead of calling RTE itself
+const ECOWATT_WAIT_FOR_REFRESH_MAX_ATTEMPTS = 20;
+const ECOWATT_WAIT_FOR_REFRESH_DEFAULT_INTERVAL_IN_MS = 500;
+// RTE answers 429 when called too often: wait several seconds between attempts
+// (2s, 4s, 8s) rather than hammering it 4 times in less than a second
+const ECOWATT_RETRY_DEFAULT_MIN_TIMEOUT_IN_MS = 2000;
 
 module.exports = function EcowattModel(logger, redisClient) {
   const { ECOWATT_BASIC_HTTP } = process.env;
+  // Overridable so tests don't have to wait for the real backoff
+  const retryMinTimeoutInMs =
+    parseInt(process.env.ECOWATT_RETRY_MIN_TIMEOUT_IN_MS, 10) || ECOWATT_RETRY_DEFAULT_MIN_TIMEOUT_IN_MS;
+  const waitForRefreshIntervalInMs =
+    parseInt(process.env.ECOWATT_WAIT_FOR_REFRESH_INTERVAL_IN_MS, 10) ||
+    ECOWATT_WAIT_FOR_REFRESH_DEFAULT_INTERVAL_IN_MS;
 
-  async function getDataFromCache() {
-    const ecowattDataFromCache = await redisClient.get(ECOWATT_CACHE_KEY);
+  async function getDataFromCache(key = ECOWATT_CACHE_KEY) {
+    const ecowattDataFromCache = await redisClient.get(key);
     // if present, return
     if (ecowattDataFromCache) {
       return JSON.parse(ecowattDataFromCache);
@@ -16,14 +39,7 @@ module.exports = function EcowattModel(logger, redisClient) {
     return null;
   }
 
-  async function getDataLiveOrFromCache() {
-    // Get data from cache
-    const dataFromCache = await getDataFromCache();
-    if (dataFromCache) {
-      logger.debug('Ecowatt: returning data from cache');
-      return dataFromCache;
-    }
-    // Get data live
+  async function getDataLive() {
     const { data: dataToken } = await axios.post('https://digital.iservices.rte-france.com/token/oauth/', null, {
       headers: {
         authorization: `Basic ${ECOWATT_BASIC_HTTP}`,
@@ -36,25 +52,99 @@ module.exports = function EcowattModel(logger, redisClient) {
       },
     });
 
-    // Set cache
-    await redisClient.set(ECOWATT_CACHE_KEY, JSON.stringify(data), {
-      EX: ECOWATT_REDIS_EXPIRY_IN_SECONDS,
-    });
+    // Set cache: the fresh copy expires, the stale copy is kept until the next successful refresh
+    const serializedData = JSON.stringify(data);
+    await redisClient
+      .multi()
+      .set(ECOWATT_CACHE_KEY, serializedData, {
+        EX: ECOWATT_REDIS_EXPIRY_IN_SECONDS,
+      })
+      .set(ECOWATT_STALE_CACHE_KEY, serializedData)
+      .exec();
 
     return data;
   }
 
-  async function getDataWithRetry() {
+  async function getDataLiveWithRetry() {
     const options = {
       retries: 3,
       factor: 2,
-      minTimeout: 50,
+      minTimeout: retryMinTimeoutInMs,
     };
-    return retry(async () => getDataLiveOrFromCache(), options);
+    return retry(async () => getDataLive(), options);
+  }
+
+  async function acquireRefreshLock() {
+    const lockAcquired = await redisClient.set(ECOWATT_REFRESH_LOCK_KEY, '1', {
+      NX: true,
+      EX: ECOWATT_REFRESH_LOCK_EXPIRY_IN_SECONDS,
+    });
+    return lockAcquired !== null;
+  }
+
+  async function releaseRefreshLock() {
+    await redisClient.del(ECOWATT_REFRESH_LOCK_KEY);
+  }
+
+  // Refresh the data from RTE, then serve the stale copy if RTE fails
+  async function refreshData(staleData) {
+    try {
+      const data = await getDataLiveWithRetry();
+      await releaseRefreshLock();
+      return data;
+    } catch (e) {
+      // The lock is kept on purpose: it expires on its own and prevents
+      // calling RTE again right away while it is failing
+      if (!staleData) {
+        throw e;
+      }
+      logger.warn(`Ecowatt: RTE failed (${e.message}), returning stale data`);
+      return staleData;
+    }
+  }
+
+  // Poll the cache until the instance holding the lock has refreshed it
+  async function waitForRefreshedData() {
+    const options = {
+      retries: ECOWATT_WAIT_FOR_REFRESH_MAX_ATTEMPTS,
+      factor: 1,
+      minTimeout: waitForRefreshIntervalInMs,
+    };
+    return retry(async () => {
+      const data = await getDataFromCache();
+      if (!data) {
+        throw new Error('Ecowatt: data is being refreshed by another instance and is not available yet');
+      }
+      return data;
+    }, options);
+  }
+
+  async function getDataLiveOrFromCache() {
+    // Get data from cache
+    const dataFromCache = await getDataFromCache();
+    if (dataFromCache) {
+      logger.debug('Ecowatt: returning data from cache');
+      return dataFromCache;
+    }
+    const staleData = await getDataFromCache(ECOWATT_STALE_CACHE_KEY);
+    if (!(await acquireRefreshLock())) {
+      // Another instance is already refreshing the data
+      if (staleData) {
+        logger.debug('Ecowatt: refresh in progress on another instance, returning stale data');
+        return staleData;
+      }
+      return waitForRefreshedData();
+    }
+    // The cache may have been refreshed between our first read and the lock
+    const dataRefreshedMeanwhile = await getDataFromCache();
+    if (dataRefreshedMeanwhile) {
+      await releaseRefreshLock();
+      return dataRefreshedMeanwhile;
+    }
+    return refreshData(staleData);
   }
 
   return {
     getDataLiveOrFromCache,
-    getDataWithRetry,
   };
 };

--- a/core/api/ecowatt/ecowatt.model.js
+++ b/core/api/ecowatt/ecowatt.model.js
@@ -1,3 +1,4 @@
+const crypto = require('crypto');
 const axios = require('axios');
 const retry = require('async-retry');
 
@@ -12,13 +13,24 @@ const ECOWATT_STALE_CACHE_KEY = 'ecowatt:data:v4:stale';
 const ECOWATT_RETRY_RETRIES = 3;
 const ECOWATT_RETRY_FACTOR = 2;
 const ECOWATT_RETRY_DEFAULT_MIN_TIMEOUT_IN_MS = 2000;
+// Bound each call to RTE so a refresh can't hang past the lock lifetime
+const ECOWATT_RTE_REQUEST_TIMEOUT_IN_MS = 5000;
 // Lock taken with SET NX EX so only one gateway instance refreshes the data
 // from RTE when the cache expires, instead of every instance at the same time
 const ECOWATT_REFRESH_LOCK_KEY = 'ecowatt:refresh-lock:v4';
-// Must cover the whole retry sequence (14s of backoff + 4 round trips to RTE),
-// see the test asserting it. A failed refresh keeps the lock until it expires,
-// which acts as a cooldown before calling RTE again
+// Must cover the whole retry sequence (14s of backoff + 4 attempts of 2 calls
+// to RTE), see the test asserting it. A failed refresh keeps the lock until it
+// expires, which acts as a cooldown before calling RTE again
 const ECOWATT_REFRESH_LOCK_EXPIRY_IN_SECONDS = 60;
+// The lock holds a token unique to the instance that took it, and is only
+// released by its owner (compare-and-delete), so a refresh that outlived the
+// lock can't delete the lock taken since by another instance
+const ECOWATT_RELEASE_LOCK_SCRIPT = `
+  if redis.call('get', KEYS[1]) == ARGV[1] then
+    return redis.call('del', KEYS[1])
+  end
+  return 0
+`;
 // An instance without any data (fresh or stale) while another one is refreshing
 // polls the cache instead of calling RTE itself, for as long as the lock lives
 const ECOWATT_WAIT_FOR_REFRESH_DEFAULT_INTERVAL_IN_MS = 500;
@@ -46,12 +58,14 @@ module.exports = function EcowattModel(logger, redisClient) {
       headers: {
         authorization: `Basic ${ECOWATT_BASIC_HTTP}`,
       },
+      timeout: ECOWATT_RTE_REQUEST_TIMEOUT_IN_MS,
     });
 
     const { data } = await axios.get('https://digital.iservices.rte-france.com/open_api/ecowatt/v5/signals', {
       headers: {
         authorization: `Bearer ${dataToken.access_token}`,
       },
+      timeout: ECOWATT_RTE_REQUEST_TIMEOUT_IN_MS,
     });
 
     // Set cache: the fresh copy expires, the stale copy is kept until the next successful refresh
@@ -76,29 +90,34 @@ module.exports = function EcowattModel(logger, redisClient) {
     return retry(async () => getDataLive(), options);
   }
 
+  // Returns the lock token when the lock was acquired, null when another instance holds it
   async function acquireRefreshLock() {
-    const lockAcquired = await redisClient.set(ECOWATT_REFRESH_LOCK_KEY, '1', {
+    const lockToken = crypto.randomUUID();
+    const lockAcquired = await redisClient.set(ECOWATT_REFRESH_LOCK_KEY, lockToken, {
       NX: true,
       EX: ECOWATT_REFRESH_LOCK_EXPIRY_IN_SECONDS,
     });
-    return lockAcquired !== null;
+    return lockAcquired === null ? null : lockToken;
   }
 
-  async function releaseRefreshLock() {
-    await redisClient.del(ECOWATT_REFRESH_LOCK_KEY);
+  async function releaseRefreshLock(lockToken) {
+    await redisClient.eval(ECOWATT_RELEASE_LOCK_SCRIPT, {
+      keys: [ECOWATT_REFRESH_LOCK_KEY],
+      arguments: [lockToken],
+    });
   }
 
   // Refresh the data from RTE, then serve the stale copy if RTE fails
-  async function refreshData(staleData) {
+  async function refreshData(staleData, lockToken) {
     try {
       const data = await getDataLiveWithRetry();
-      await releaseRefreshLock();
+      await releaseRefreshLock(lockToken);
       return data;
     } catch (e) {
       if (!staleData) {
         // Nothing to serve: release the lock so the instances waiting on it
         // fail right away instead of polling until the lock expires
-        await releaseRefreshLock();
+        await releaseRefreshLock(lockToken);
         throw e;
       }
       // The lock is kept on purpose: it expires on its own and prevents
@@ -141,7 +160,8 @@ module.exports = function EcowattModel(logger, redisClient) {
       return dataFromCache;
     }
     const staleData = await getDataFromCache(ECOWATT_STALE_CACHE_KEY);
-    if (!(await acquireRefreshLock())) {
+    const lockToken = await acquireRefreshLock();
+    if (!lockToken) {
       // Another instance is already refreshing the data
       if (staleData) {
         logger.debug('Ecowatt: refresh in progress on another instance, returning stale data');
@@ -152,10 +172,10 @@ module.exports = function EcowattModel(logger, redisClient) {
     // The cache may have been refreshed between our first read and the lock
     const dataRefreshedMeanwhile = await getDataFromCache();
     if (dataRefreshedMeanwhile) {
-      await releaseRefreshLock();
+      await releaseRefreshLock(lockToken);
       return dataRefreshedMeanwhile;
     }
-    return refreshData(staleData);
+    return refreshData(staleData, lockToken);
   }
 
   return {
@@ -171,4 +191,5 @@ module.exports.constants = {
   ECOWATT_RETRY_RETRIES,
   ECOWATT_RETRY_FACTOR,
   ECOWATT_RETRY_DEFAULT_MIN_TIMEOUT_IN_MS,
+  ECOWATT_RTE_REQUEST_TIMEOUT_IN_MS,
 };

--- a/core/api/ecowatt/ecowatt.model.js
+++ b/core/api/ecowatt/ecowatt.model.js
@@ -7,19 +7,21 @@ const ECOWATT_REDIS_EXPIRY_IN_SECONDS = 60 * 60; // 1 hour
 // Last data successfully fetched from RTE, kept without TTL so it can still be
 // served when RTE fails (429 / 500) instead of failing the request
 const ECOWATT_STALE_CACHE_KEY = 'ecowatt:data:v4:stale';
+// RTE answers 429 when called too often: wait several seconds between attempts
+// (2s, 4s, 8s) rather than hammering it 4 times in less than a second
+const ECOWATT_RETRY_RETRIES = 3;
+const ECOWATT_RETRY_FACTOR = 2;
+const ECOWATT_RETRY_DEFAULT_MIN_TIMEOUT_IN_MS = 2000;
 // Lock taken with SET NX EX so only one gateway instance refreshes the data
 // from RTE when the cache expires, instead of every instance at the same time
 const ECOWATT_REFRESH_LOCK_KEY = 'ecowatt:refresh-lock:v4';
-// Must cover the whole retry sequence (see getDataLiveWithRetry). A failed refresh
-// keeps the lock until it expires, which acts as a cooldown before calling RTE again
+// Must cover the whole retry sequence (14s of backoff + 4 round trips to RTE),
+// see the test asserting it. A failed refresh keeps the lock until it expires,
+// which acts as a cooldown before calling RTE again
 const ECOWATT_REFRESH_LOCK_EXPIRY_IN_SECONDS = 60;
 // An instance without any data (fresh or stale) while another one is refreshing
-// polls the cache instead of calling RTE itself
-const ECOWATT_WAIT_FOR_REFRESH_MAX_ATTEMPTS = 20;
+// polls the cache instead of calling RTE itself, for as long as the lock lives
 const ECOWATT_WAIT_FOR_REFRESH_DEFAULT_INTERVAL_IN_MS = 500;
-// RTE answers 429 when called too often: wait several seconds between attempts
-// (2s, 4s, 8s) rather than hammering it 4 times in less than a second
-const ECOWATT_RETRY_DEFAULT_MIN_TIMEOUT_IN_MS = 2000;
 
 module.exports = function EcowattModel(logger, redisClient) {
   const { ECOWATT_BASIC_HTTP } = process.env;
@@ -67,8 +69,8 @@ module.exports = function EcowattModel(logger, redisClient) {
 
   async function getDataLiveWithRetry() {
     const options = {
-      retries: 3,
-      factor: 2,
+      retries: ECOWATT_RETRY_RETRIES,
+      factor: ECOWATT_RETRY_FACTOR,
       minTimeout: retryMinTimeoutInMs,
     };
     return retry(async () => getDataLive(), options);
@@ -93,29 +95,41 @@ module.exports = function EcowattModel(logger, redisClient) {
       await releaseRefreshLock();
       return data;
     } catch (e) {
-      // The lock is kept on purpose: it expires on its own and prevents
-      // calling RTE again right away while it is failing
       if (!staleData) {
+        // Nothing to serve: release the lock so the instances waiting on it
+        // fail right away instead of polling until the lock expires
+        await releaseRefreshLock();
         throw e;
       }
+      // The lock is kept on purpose: it expires on its own and prevents
+      // calling RTE again right away while it is failing
       logger.warn(`Ecowatt: RTE failed (${e.message}), returning stale data`);
       return staleData;
     }
   }
 
-  // Poll the cache until the instance holding the lock has refreshed it
+  // Poll the cache until the instance holding the lock has refreshed it. The wait
+  // is bounded by the lock lifetime, which always covers the holder's retry
+  // sequence, and stops early once the lock is gone: the holder either succeeded
+  // (the data is in cache) or failed without stale data (the lock was released)
   async function waitForRefreshedData() {
     const options = {
-      retries: ECOWATT_WAIT_FOR_REFRESH_MAX_ATTEMPTS,
+      retries: Math.ceil((ECOWATT_REFRESH_LOCK_EXPIRY_IN_SECONDS * 1000) / waitForRefreshIntervalInMs),
       factor: 1,
       minTimeout: waitForRefreshIntervalInMs,
     };
-    return retry(async () => {
+    return retry(async (bail) => {
+      // Read the lock before the data: the holder writes the data before releasing the lock
+      const lockStillHeld = await redisClient.exists(ECOWATT_REFRESH_LOCK_KEY);
       const data = await getDataFromCache();
-      if (!data) {
-        throw new Error('Ecowatt: data is being refreshed by another instance and is not available yet');
+      if (data) {
+        return data;
       }
-      return data;
+      if (!lockStillHeld) {
+        bail(new Error('Ecowatt: no data available, the refresh on another instance failed'));
+        return null;
+      }
+      throw new Error('Ecowatt: data is being refreshed by another instance and is not available yet');
     }, options);
   }
 
@@ -147,4 +161,14 @@ module.exports = function EcowattModel(logger, redisClient) {
   return {
     getDataLiveOrFromCache,
   };
+};
+
+module.exports.constants = {
+  ECOWATT_CACHE_KEY,
+  ECOWATT_STALE_CACHE_KEY,
+  ECOWATT_REFRESH_LOCK_KEY,
+  ECOWATT_REFRESH_LOCK_EXPIRY_IN_SECONDS,
+  ECOWATT_RETRY_RETRIES,
+  ECOWATT_RETRY_FACTOR,
+  ECOWATT_RETRY_DEFAULT_MIN_TIMEOUT_IN_MS,
 };

--- a/core/api/ecowatt/ecowatt.model.js
+++ b/core/api/ecowatt/ecowatt.model.js
@@ -86,6 +86,9 @@ module.exports = function EcowattModel(logger, redisClient) {
       retries: ECOWATT_RETRY_RETRIES,
       factor: ECOWATT_RETRY_FACTOR,
       minTimeout: retryMinTimeoutInMs,
+      // async-retry jitters the backoff by default (1x to 2x): keep it exact so the
+      // whole sequence stays within the lock lifetime (see the constants test)
+      randomize: false,
     };
     return retry(async () => getDataLive(), options);
   }
@@ -136,6 +139,7 @@ module.exports = function EcowattModel(logger, redisClient) {
       retries: Math.ceil((ECOWATT_REFRESH_LOCK_EXPIRY_IN_SECONDS * 1000) / waitForRefreshIntervalInMs),
       factor: 1,
       minTimeout: waitForRefreshIntervalInMs,
+      randomize: false,
     };
     return retry(async (bail) => {
       // Read the lock before the data: the holder writes the data before releasing the lock

--- a/test/bootstrap.test.js
+++ b/test/bootstrap.test.js
@@ -33,6 +33,9 @@ before(async function Before() {
   process.env.OPEN_AI_MAX_TEXT_REQUESTS_PER_MONTH_PER_ACCOUNT = 100;
   process.env.OPEN_AI_MAX_IMAGE_REQUESTS_PER_MONTH_PER_ACCOUNT = 100;
   process.env.STT_MAX_REQUESTS_PER_MONTH_PER_ACCOUNT = 100;
+  // Don't wait for the real RTE backoff / refresh polling in tests
+  process.env.ECOWATT_RETRY_MIN_TIMEOUT_IN_MS = 10;
+  process.env.ECOWATT_WAIT_FOR_REFRESH_INTERVAL_IN_MS = 20;
 
   // starting 2 backends to try multi-server socket exchange
   const { io, app, db, redisClient, legacyRedisClient } = await server(process.env.SERVER_PORT);

--- a/test/core/api/ecowatt/ecowatt.controller.test.js
+++ b/test/core/api/ecowatt/ecowatt.controller.test.js
@@ -12,6 +12,7 @@ const {
   ECOWATT_RETRY_RETRIES,
   ECOWATT_RETRY_FACTOR,
   ECOWATT_RETRY_DEFAULT_MIN_TIMEOUT_IN_MS,
+  ECOWATT_RTE_REQUEST_TIMEOUT_IN_MS,
 } = constants;
 
 const RTE_HOST = 'https://digital.iservices.rte-france.com';
@@ -46,12 +47,13 @@ const getEcowattSignals = (status = 200) =>
 
 describe('GET /ecowatt/v4/signals', () => {
   it('should keep the refresh lock longer than the whole RTE retry sequence', () => {
-    // Instances without data wait for the lock holder as long as the lock lives:
-    // the lock must outlive the backoff (2s + 4s + 8s) plus the RTE round trips
+    // Instances without data wait for the lock holder as long as the lock lives: the lock
+    // must outlive the backoff (2s + 4s + 8s) plus the 2 calls to RTE of each of the 4 attempts
     const totalBackoffInMs =
       ECOWATT_RETRY_DEFAULT_MIN_TIMEOUT_IN_MS * (ECOWATT_RETRY_FACTOR ** ECOWATT_RETRY_RETRIES - 1);
+    const totalRequestsInMs = (ECOWATT_RETRY_RETRIES + 1) * 2 * ECOWATT_RTE_REQUEST_TIMEOUT_IN_MS;
     expect(totalBackoffInMs).to.equal(14000);
-    expect(ECOWATT_REFRESH_LOCK_EXPIRY_IN_SECONDS * 1000).to.be.above(totalBackoffInMs + 4 * 5000);
+    expect(ECOWATT_REFRESH_LOCK_EXPIRY_IN_SECONDS * 1000).to.be.above(totalBackoffInMs + totalRequestsInMs);
   });
   it('should return ecowatt data without retry', async () => {
     const rteToken = nockRteToken();
@@ -163,6 +165,17 @@ describe('GET /ecowatt/v4/signals', () => {
     await getEcowattSignals(500);
     expect(Date.now() - startedAt).to.be.above(150);
     assertRteNotCalled();
+  });
+  it('should not release a lock taken by another instance after the refresh outlived its own lock', async () => {
+    nockRteToken();
+    nock(RTE_HOST).get('/open_api/ecowatt/v5/signals').delay(100).reply(200, { data: true });
+    // Simulate the lock expiring and being taken by another instance while RTE is still answering
+    setTimeout(() => {
+      TEST_LEGACY_REDIS_CLIENT.v4.set(ECOWATT_REFRESH_LOCK_KEY, 'other-instance-token', { EX: 60 });
+    }, 50);
+    const response = await getEcowattSignals();
+    expect(response.body).to.deep.equal({ data: true });
+    expect(await TEST_LEGACY_REDIS_CLIENT.v4.get(ECOWATT_REFRESH_LOCK_KEY)).to.equal('other-instance-token');
   });
   it('should only call RTE once for concurrent requests when the cache expired', async () => {
     const rteToken = nockRteToken();

--- a/test/core/api/ecowatt/ecowatt.controller.test.js
+++ b/test/core/api/ecowatt/ecowatt.controller.test.js
@@ -2,9 +2,17 @@ const request = require('supertest');
 const { expect } = require('chai');
 const nock = require('nock');
 
-const ECOWATT_CACHE_KEY = 'ecowatt:data:v4';
-const ECOWATT_STALE_CACHE_KEY = 'ecowatt:data:v4:stale';
-const ECOWATT_REFRESH_LOCK_KEY = 'ecowatt:refresh-lock:v4';
+const { constants } = require('../../../../core/api/ecowatt/ecowatt.model');
+
+const {
+  ECOWATT_CACHE_KEY,
+  ECOWATT_STALE_CACHE_KEY,
+  ECOWATT_REFRESH_LOCK_KEY,
+  ECOWATT_REFRESH_LOCK_EXPIRY_IN_SECONDS,
+  ECOWATT_RETRY_RETRIES,
+  ECOWATT_RETRY_FACTOR,
+  ECOWATT_RETRY_DEFAULT_MIN_TIMEOUT_IN_MS,
+} = constants;
 
 const RTE_HOST = 'https://digital.iservices.rte-france.com';
 
@@ -37,6 +45,14 @@ const getEcowattSignals = (status = 200) =>
     .expect(status);
 
 describe('GET /ecowatt/v4/signals', () => {
+  it('should keep the refresh lock longer than the whole RTE retry sequence', () => {
+    // Instances without data wait for the lock holder as long as the lock lives:
+    // the lock must outlive the backoff (2s + 4s + 8s) plus the RTE round trips
+    const totalBackoffInMs =
+      ECOWATT_RETRY_DEFAULT_MIN_TIMEOUT_IN_MS * (ECOWATT_RETRY_FACTOR ** ECOWATT_RETRY_RETRIES - 1);
+    expect(totalBackoffInMs).to.equal(14000);
+    expect(ECOWATT_REFRESH_LOCK_EXPIRY_IN_SECONDS * 1000).to.be.above(totalBackoffInMs + 4 * 5000);
+  });
   it('should return ecowatt data without retry', async () => {
     const rteToken = nockRteToken();
     const rteSignals = nockRteSignals(200, { data: true });
@@ -117,6 +133,8 @@ describe('GET /ecowatt/v4/signals', () => {
     }
     await getEcowattSignals(500);
     rteScopes.forEach((scope) => expect(scope.isDone()).to.equal(true));
+    // No stale data to serve: the lock is released so waiting instances fail right away
+    expect(await TEST_LEGACY_REDIS_CLIENT.v4.get(ECOWATT_REFRESH_LOCK_KEY)).to.equal(null);
   });
   it('should return stale data without calling RTE when another instance is refreshing', async () => {
     await TEST_LEGACY_REDIS_CLIENT.v4.set(ECOWATT_STALE_CACHE_KEY, JSON.stringify({ data: 'stale' }));
@@ -137,10 +155,13 @@ describe('GET /ecowatt/v4/signals', () => {
     expect(response.body).to.deep.equal({ data: 'refreshed' });
     assertRteNotCalled();
   });
-  it('should fail when the other instance never refreshes the data and there is no stale data', async () => {
-    await TEST_LEGACY_REDIS_CLIENT.v4.set(ECOWATT_REFRESH_LOCK_KEY, '1', { EX: 60 });
+  it('should fail once the other instance released the lock without refreshing the data', async () => {
+    // The lock expires without data: the holder failed and had no stale data to serve
+    await TEST_LEGACY_REDIS_CLIENT.v4.set(ECOWATT_REFRESH_LOCK_KEY, '1', { PX: 200 });
     const assertRteNotCalled = expectRteNotCalled();
+    const startedAt = Date.now();
     await getEcowattSignals(500);
+    expect(Date.now() - startedAt).to.be.above(150);
     assertRteNotCalled();
   });
   it('should only call RTE once for concurrent requests when the cache expired', async () => {

--- a/test/core/api/ecowatt/ecowatt.controller.test.js
+++ b/test/core/api/ecowatt/ecowatt.controller.test.js
@@ -2,83 +2,155 @@ const request = require('supertest');
 const { expect } = require('chai');
 const nock = require('nock');
 
+const ECOWATT_CACHE_KEY = 'ecowatt:data:v4';
+const ECOWATT_STALE_CACHE_KEY = 'ecowatt:data:v4:stale';
+const ECOWATT_REFRESH_LOCK_KEY = 'ecowatt:refresh-lock:v4';
+
+const RTE_HOST = 'https://digital.iservices.rte-france.com';
+
+const nockRteToken = () =>
+  nock(RTE_HOST)
+    .post('/token/oauth/', () => true)
+    .reply(200, {
+      access_token: 'access_token',
+      expires_in: 100,
+    });
+
+// Interceptor that must stay unused: asserts it was never called then removes it
+// so it doesn't leak into the next tests
+const expectRteNotCalled = () => {
+  const interceptor = nock(RTE_HOST).post('/token/oauth/', () => true);
+  const scope = interceptor.reply(200, { access_token: 'access_token', expires_in: 100 });
+  return () => {
+    expect(scope.isDone()).to.equal(false);
+    nock.removeInterceptor(interceptor);
+  };
+};
+
+const nockRteSignals = (status, body) => nock(RTE_HOST).get('/open_api/ecowatt/v5/signals').reply(status, body);
+
+const getEcowattSignals = (status = 200) =>
+  request(TEST_BACKEND_APP)
+    .get('/ecowatt/v4/signals')
+    .set('Accept', 'application/json')
+    .expect('Content-Type', /json/)
+    .expect(status);
+
 describe('GET /ecowatt/v4/signals', () => {
   it('should return ecowatt data without retry', async () => {
-    nock('https://digital.iservices.rte-france.com')
-      .post('/token/oauth/', () => true)
-      .reply(200, {
-        access_token: 'access_token',
-        expires_in: 100,
-      });
-    nock('https://digital.iservices.rte-france.com').get('/open_api/ecowatt/v5/signals').reply(200, {
-      data: true,
-    });
-    const response = await request(TEST_BACKEND_APP)
-      .get('/ecowatt/v4/signals')
-      .set('Accept', 'application/json')
-      .expect('Content-Type', /json/)
-      .expect(200);
+    const rteToken = nockRteToken();
+    const rteSignals = nockRteSignals(200, { data: true });
+    const response = await getEcowattSignals();
     expect(response.headers).to.have.property('cache-control', 'public, max-age=3600');
     expect(response.body).to.deep.equal({
       data: true,
     });
     // From cache
-    const responseFromCache = await request(TEST_BACKEND_APP)
-      .get('/ecowatt/v4/signals')
-      .set('Accept', 'application/json')
-      .expect('Content-Type', /json/)
-      .expect(200);
+    const responseFromCache = await getEcowattSignals();
     expect(responseFromCache.headers).to.have.property('cache-control', 'public, max-age=3600');
     expect(responseFromCache.body).to.deep.equal({
       data: true,
     });
+    expect(rteToken.isDone()).to.equal(true);
+    expect(rteSignals.isDone()).to.equal(true);
+  });
+  it('should keep a fresh copy with a TTL, a stale copy without TTL, and release the lock', async () => {
+    nockRteToken();
+    nockRteSignals(200, { data: true });
+    await getEcowattSignals();
+    expect(await TEST_LEGACY_REDIS_CLIENT.v4.ttl(ECOWATT_CACHE_KEY)).to.be.above(0);
+    expect(await TEST_LEGACY_REDIS_CLIENT.v4.ttl(ECOWATT_STALE_CACHE_KEY)).to.equal(-1);
+    expect(JSON.parse(await TEST_LEGACY_REDIS_CLIENT.v4.get(ECOWATT_STALE_CACHE_KEY))).to.deep.equal({ data: true });
+    expect(await TEST_LEGACY_REDIS_CLIENT.v4.get(ECOWATT_REFRESH_LOCK_KEY)).to.equal(null);
   });
   it('should return ecowatt data with 2 retry', async () => {
-    nock('https://digital.iservices.rte-france.com')
-      .post('/token/oauth/', () => true)
-      .reply(200, {
-        access_token: 'access_token',
-        expires_in: 100,
-      });
-    nock('https://digital.iservices.rte-france.com')
-      .post('/token/oauth/', () => true)
-      .reply(200, {
-        access_token: 'access_token',
-        expires_in: 100,
-      });
-    nock('https://digital.iservices.rte-france.com')
-      .post('/token/oauth/', () => true)
-      .reply(200, {
-        access_token: 'access_token',
-        expires_in: 100,
-      });
-    nock('https://digital.iservices.rte-france.com').get('/open_api/ecowatt/v5/signals').reply(429, {
-      error: 'too many requests',
-    });
-    nock('https://digital.iservices.rte-france.com').get('/open_api/ecowatt/v5/signals').reply(429, {
-      error: 'too many requests',
-    });
-    nock('https://digital.iservices.rte-france.com').get('/open_api/ecowatt/v5/signals').reply(200, {
-      data: true,
-    });
-    const response = await request(TEST_BACKEND_APP)
-      .get('/ecowatt/v4/signals')
-      .set('Accept', 'application/json')
-      .expect('Content-Type', /json/)
-      .expect(200);
+    const rteScopes = [
+      nockRteToken(),
+      nockRteToken(),
+      nockRteToken(),
+      nockRteSignals(429, { error: 'too many requests' }),
+      nockRteSignals(429, { error: 'too many requests' }),
+      nockRteSignals(200, { data: true }),
+    ];
+    const response = await getEcowattSignals();
     expect(response.headers).to.have.property('cache-control', 'public, max-age=3600');
     expect(response.body).to.deep.equal({
       data: true,
     });
     // From cache
-    const responseFromCache = await request(TEST_BACKEND_APP)
-      .get('/ecowatt/v4/signals')
-      .set('Accept', 'application/json')
-      .expect('Content-Type', /json/)
-      .expect(200);
+    const responseFromCache = await getEcowattSignals();
     expect(responseFromCache.headers).to.have.property('cache-control', 'public, max-age=3600');
     expect(responseFromCache.body).to.deep.equal({
       data: true,
     });
+    rteScopes.forEach((scope) => expect(scope.isDone()).to.equal(true));
+  });
+  it('should return stale data when RTE keeps answering 429 after the cache expired', async () => {
+    await TEST_LEGACY_REDIS_CLIENT.v4.set(ECOWATT_STALE_CACHE_KEY, JSON.stringify({ data: 'stale' }));
+    // 1 call + 3 retries
+    const rteScopes = [];
+    for (let i = 0; i < 4; i += 1) {
+      rteScopes.push(nockRteToken(), nockRteSignals(429, { error: 'too many requests' }));
+    }
+    const response = await getEcowattSignals();
+    expect(response.body).to.deep.equal({ data: 'stale' });
+    rteScopes.forEach((scope) => expect(scope.isDone()).to.equal(true));
+    // The lock is kept as a cooldown: the next request doesn't call RTE again
+    expect(await TEST_LEGACY_REDIS_CLIENT.v4.ttl(ECOWATT_REFRESH_LOCK_KEY)).to.be.above(0);
+    const responseDuringCooldown = await getEcowattSignals();
+    expect(responseDuringCooldown.body).to.deep.equal({ data: 'stale' });
+  });
+  it('should return stale data when RTE token endpoint answers 500', async () => {
+    await TEST_LEGACY_REDIS_CLIENT.v4.set(ECOWATT_STALE_CACHE_KEY, JSON.stringify({ data: 'stale' }));
+    const rteToken = nock(RTE_HOST)
+      .post('/token/oauth/', () => true)
+      .times(4)
+      .reply(500, { error: 'internal error' });
+    const response = await getEcowattSignals();
+    expect(response.body).to.deep.equal({ data: 'stale' });
+    expect(rteToken.isDone()).to.equal(true);
+  });
+  it('should fail when RTE fails and there is no stale data', async () => {
+    const rteScopes = [];
+    for (let i = 0; i < 4; i += 1) {
+      rteScopes.push(nockRteToken(), nockRteSignals(429, { error: 'too many requests' }));
+    }
+    await getEcowattSignals(500);
+    rteScopes.forEach((scope) => expect(scope.isDone()).to.equal(true));
+  });
+  it('should return stale data without calling RTE when another instance is refreshing', async () => {
+    await TEST_LEGACY_REDIS_CLIENT.v4.set(ECOWATT_STALE_CACHE_KEY, JSON.stringify({ data: 'stale' }));
+    await TEST_LEGACY_REDIS_CLIENT.v4.set(ECOWATT_REFRESH_LOCK_KEY, '1', { EX: 60 });
+    const assertRteNotCalled = expectRteNotCalled();
+    const response = await getEcowattSignals();
+    expect(response.body).to.deep.equal({ data: 'stale' });
+    assertRteNotCalled();
+  });
+  it('should wait for the other instance to refresh the data when there is no stale data', async () => {
+    await TEST_LEGACY_REDIS_CLIENT.v4.set(ECOWATT_REFRESH_LOCK_KEY, '1', { EX: 60 });
+    const assertRteNotCalled = expectRteNotCalled();
+    // Simulate the instance holding the lock filling the cache a bit later
+    setTimeout(() => {
+      TEST_LEGACY_REDIS_CLIENT.v4.set(ECOWATT_CACHE_KEY, JSON.stringify({ data: 'refreshed' }), { EX: 60 });
+    }, 50);
+    const response = await getEcowattSignals();
+    expect(response.body).to.deep.equal({ data: 'refreshed' });
+    assertRteNotCalled();
+  });
+  it('should fail when the other instance never refreshes the data and there is no stale data', async () => {
+    await TEST_LEGACY_REDIS_CLIENT.v4.set(ECOWATT_REFRESH_LOCK_KEY, '1', { EX: 60 });
+    const assertRteNotCalled = expectRteNotCalled();
+    await getEcowattSignals(500);
+    assertRteNotCalled();
+  });
+  it('should only call RTE once for concurrent requests when the cache expired', async () => {
+    const rteToken = nockRteToken();
+    const rteSignals = nockRteSignals(200, { data: true });
+    const responses = await Promise.all([getEcowattSignals(), getEcowattSignals(), getEcowattSignals()]);
+    responses.forEach((response) => {
+      expect(response.body).to.deep.equal({ data: true });
+    });
+    expect(rteToken.isDone()).to.equal(true);
+    expect(rteSignals.isDone()).to.equal(true);
   });
 });


### PR DESCRIPTION
## Context

Sentry [GLADYS-GATEWAY-CY](https://gladys-assistant.sentry.io/issues/GLADYS-GATEWAY-CY) (429, 355 events) and [GLADYS-GATEWAY-DP](https://gladys-assistant.sentry.io/issues/GLADYS-GATEWAY-DP) (500 on the token endpoint) on `GET /ecowatt/v4/signals`.

The events come in bursts when the 1h Redis cache expires: every gateway instance calls RTE at the same time, and the retry with a 50 ms base made 4 calls in under a second, which makes the 429 worse. Any RTE failure was turned into a 500 for the Gladys instance.

## Changes (`core/api/ecowatt/ecowatt.model.js`)

- **Stale copy without TTL**: on every successful fetch the data is written both to the 1h key and to `ecowatt:data:v4:stale` (no TTL). When RTE still fails after the retries, the stale copy is served with a warning log instead of failing the request. The request only fails when there is no stale copy at all (first deploy / Redis flushed).
- **Refresh lock** (`SET NX EX`, 60s, same pattern as the Google Home request sync lock): only one instance refreshes the data. The others serve the stale copy, or, if there is none yet, poll the cache (500 ms × 20) until the lock holder fills it. The cache is re-checked after taking the lock. The lock is released on success and kept on failure, so it acts as a cooldown before calling RTE again.
- **Backoff**: `minTimeout` goes from 50 ms to 2 s (2s, 4s, 8s between the 3 retries).

`ECOWATT_RETRY_MIN_TIMEOUT_IN_MS` and `ECOWATT_WAIT_FOR_REFRESH_INTERVAL_IN_MS` are only read to shorten the delays in tests (set in `test/bootstrap.test.js`).

## Tests

`test/core/api/ecowatt/ecowatt.controller.test.js` covers: fresh/stale keys and TTLs, retry then success, stale data served on 429 and on token 500, failure without stale data, lock held by another instance (stale served / wait for refresh / wait timeout), and a single RTE call for concurrent requests.

Ran locally: ecowatt tests, prettier, eslint. In the full suite only the pre-existing backup/camera (S3) and Google (service account) tests fail, for lack of the CI secrets locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UrAkneobeVafZzN49DYp95

---
_Generated by [Claude Code](https://claude.ai/code/session_01UrAkneobeVafZzN49DYp95)_