### PR TITLE
Map AI service failures on /openai/ask to clean 502/504 and count them in Sentry

### DIFF
--- a/core/api/openai/openai.controller.js
+++ b/core/api/openai/openai.controller.js
@@ -1,4 +1,14 @@
 const axios = require('axios');
+const { mapUpstreamError } = require('../../service/upstreamError');
+
+// How long we wait for the AI service before answering 504 ourselves.
+// Keeps a hung upstream from holding gateway connections forever.
+const DEFAULT_ASK_TIMEOUT_MS = 60 * 1000;
+
+function getAskTimeoutMs() {
+  const configured = parseInt(process.env.OPEN_AI_ASK_TIMEOUT_MS, 10);
+  return Number.isFinite(configured) && configured > 0 ? configured : DEFAULT_ASK_TIMEOUT_MS;
+}
 
 module.exports = function OpenAIController(openAIModel) {
   /**
@@ -27,11 +37,19 @@ module.exports = function OpenAIController(openAIModel) {
       ? req.body.categories.filter((category) => typeof category === 'string')
       : null;
     const startTime = Date.now();
-    const { data } = await axios.post(process.env.OPEN_AI_ASK_API_URL, req.body, {
-      headers: {
-        authorization: `Bearer ${process.env.OPEN_AI_ASK_API_KEY}`,
-      },
-    });
+    let data;
+    try {
+      ({ data } = await axios.post(process.env.OPEN_AI_ASK_API_URL, req.body, {
+        headers: {
+          authorization: `Bearer ${process.env.OPEN_AI_ASK_API_KEY}`,
+        },
+        timeout: getAskTimeoutMs(),
+      }));
+    } catch (e) {
+      // The AI service timing out or failing is not a gateway bug: answer a clean
+      // 504 / 502 and count it in Sentry instead of reporting a generic 500 exception.
+      throw mapUpstreamError('openai_ask', e, 'AI service');
+    }
     const responseTimeMs = Date.now() - startTime;
     const usage = data && data.usage ? data.usage : {};
     const firstChoice = data && data.choices && data.choices.length > 0 ? data.choices[0] : {};

--- a/core/common/error.js
+++ b/core/common/error.js
@@ -231,6 +231,65 @@ class PaymentRequiredError extends Error {
   }
 }
 
+/**
+ * The gateway relayed the request to an upstream service (AI provider, ...)
+ * that answered with an error or could not be reached. Not a gateway bug.
+ * `upstream` is a compact description of the upstream failure, used for logging only.
+ */
+class BadGatewayError extends Error {
+  constructor(errorMessage, upstream) {
+    super(errorMessage || 'Bad Gateway');
+    this.errorMessage = errorMessage || 'Bad Gateway';
+    this.upstream = upstream || null;
+    this.code = 502;
+
+    // the next line is important so that the constructor is not part
+    // of the resulting stacktrace
+    Error.captureStackTrace(this, BadGatewayError);
+  }
+
+  jsonError() {
+    return {
+      status: this.code,
+      error_code: 'BAD_GATEWAY',
+      error_message: this.errorMessage,
+    };
+  }
+
+  getStatus() {
+    return this.code;
+  }
+}
+
+/**
+ * The upstream service did not answer in time (client-side timeout or 504 from
+ * the upstream itself). Not a gateway bug.
+ */
+class GatewayTimeoutError extends Error {
+  constructor(errorMessage, upstream) {
+    super(errorMessage || 'Gateway Timeout');
+    this.errorMessage = errorMessage || 'Gateway Timeout';
+    this.upstream = upstream || null;
+    this.code = 504;
+
+    // the next line is important so that the constructor is not part
+    // of the resulting stacktrace
+    Error.captureStackTrace(this, GatewayTimeoutError);
+  }
+
+  jsonError() {
+    return {
+      status: this.code,
+      error_code: 'GATEWAY_TIMEOUT',
+      error_message: this.errorMessage,
+    };
+  }
+
+  getStatus() {
+    return this.code;
+  }
+}
+
 module.exports.ValidationError = ValidationError;
 module.exports.BadRequestError = BadRequestError;
 module.exports.AlreadyExistError = AlreadyExistError;
@@ -240,3 +299,5 @@ module.exports.UnauthorizedError = UnauthorizedError;
 module.exports.ServerError = ServerError;
 module.exports.PaymentRequiredError = PaymentRequiredError;
 module.exports.TooManyRequestsError = TooManyRequestsError;
+module.exports.BadGatewayError = BadGatewayError;
+module.exports.GatewayTimeoutError = GatewayTimeoutError;

--- a/core/middleware/errorMiddleware.js
+++ b/core/middleware/errorMiddleware.js
@@ -8,7 +8,10 @@ const {
   PaymentRequiredError,
   BadRequestError,
   TooManyRequestsError,
+  BadGatewayError,
+  GatewayTimeoutError,
 } = require('../common/error');
+const { isAxiosError, formatAxiosError } = require('../service/upstreamError');
 
 const EXPECTED_CLIENT_ERRORS = [
   ValidationError,
@@ -21,17 +24,26 @@ const EXPECTED_CLIENT_ERRORS = [
   PaymentRequiredError,
 ];
 
+// Upstream failures (AI provider down or slow) mapped to clean 502/504 by the
+// controllers: operational, counted as Sentry metrics, never reported as exceptions.
+const EXPECTED_UPSTREAM_ERRORS = [BadGatewayError, GatewayTimeoutError];
+
 function isExpectedClientError(error) {
   return EXPECTED_CLIENT_ERRORS.some((ErrorClass) => error instanceof ErrorClass);
+}
+
+function isExpectedUpstreamError(error) {
+  return EXPECTED_UPSTREAM_ERRORS.some((ErrorClass) => error instanceof ErrorClass);
 }
 
 /**
  * Sentry should only receive errors that are actual bugs.
  * Expected client errors (4xx we raise on purpose: 400, 401, 402, 403, 404, 409, 422, 429)
- * are handled by the error middleware and must not be reported.
+ * and expected upstream errors (502 / 504 when a third-party service fails, counted
+ * as metrics instead) are handled by the error middleware and must not be reported.
  */
 function shouldReportErrorToSentry(error) {
-  if (isExpectedClientError(error)) {
+  if (isExpectedClientError(error) || isExpectedUpstreamError(error)) {
     return false;
   }
   // generic 404 raised by third-party middlewares (e.g. express static / proxy)
@@ -41,48 +53,11 @@ function shouldReportErrorToSentry(error) {
   return true;
 }
 
-function isAxiosError(error) {
-  return Boolean(error && (error.isAxiosError === true || error.name === 'AxiosError'));
-}
-
 function formatRequestContext(req) {
   const method = req.method || '?';
   const path = (req.route && req.route.path) || req.originalUrl || req.url || '?';
   const userId = req.user && req.user.id ? req.user.id : '—';
   return `${method} ${path} user=${userId}`;
-}
-
-function summarizeResponseData(data) {
-  if (data == null) {
-    return '';
-  }
-  if (typeof data === 'string') {
-    return data.slice(0, 200);
-  }
-  if (typeof data.error === 'string') {
-    return data.error.slice(0, 200);
-  }
-  if (data.error && data.error.message) {
-    return String(data.error.message).slice(0, 200);
-  }
-  if (data.message) {
-    return String(data.message).slice(0, 200);
-  }
-  try {
-    return JSON.stringify(data).slice(0, 200);
-  } catch (e) {
-    return '';
-  }
-}
-
-function formatAxiosError(error) {
-  const method = ((error.config && error.config.method) || '?').toUpperCase();
-  const url = (error.config && error.config.url) || '?';
-  const status = (error.response && error.response.status) || error.code || '?';
-  const statusText = (error.response && error.response.statusText) || '';
-  const detail = summarizeResponseData(error.response && error.response.data);
-  const statusPart = statusText ? `${status} ${statusText}` : String(status);
-  return `Axios ${method} ${url} → ${statusPart}${detail ? ` — ${detail}` : ''}`;
 }
 
 function formatUnexpectedError(error) {
@@ -99,6 +74,10 @@ function getErrorMiddleware(logger) {
       const code = error.code || (error.getStatus && error.getStatus()) || 400;
       const message = error.errorMessage || error.message || error.constructor.name;
       logger.warn(`${code} ${message} ${context}`);
+    } else if (isExpectedUpstreamError(error)) {
+      // Upstream failure already mapped to a clean 502/504: one warn line with the upstream detail
+      const upstream = error.upstream ? ` (${error.upstream})` : '';
+      logger.warn(`${error.getStatus()} ${error.errorMessage}${upstream} ${context}`);
     } else if (error && error.type === 'StripeCardError') {
       logger.warn(`402 ${error.message} ${context}`);
     } else if (error && error.statusCode === 404) {
@@ -113,7 +92,7 @@ function getErrorMiddleware(logger) {
       }
     }
 
-    if (isExpectedClientError(error)) {
+    if (isExpectedClientError(error) || isExpectedUpstreamError(error)) {
       return res.status(error.getStatus()).json(error.jsonError());
     }
 
@@ -135,5 +114,7 @@ function getErrorMiddleware(logger) {
 
 module.exports = getErrorMiddleware;
 module.exports.EXPECTED_CLIENT_ERRORS = EXPECTED_CLIENT_ERRORS;
+module.exports.EXPECTED_UPSTREAM_ERRORS = EXPECTED_UPSTREAM_ERRORS;
 module.exports.isExpectedClientError = isExpectedClientError;
+module.exports.isExpectedUpstreamError = isExpectedUpstreamError;
 module.exports.shouldReportErrorToSentry = shouldReportErrorToSentry;

--- a/core/service/upstreamError.js
+++ b/core/service/upstreamError.js
@@ -1,0 +1,126 @@
+const Sentry = require('@sentry/node');
+const { BadGatewayError, GatewayTimeoutError } = require('../common/error');
+
+// Name of the Sentry counter incremented for every upstream failure.
+// Attributes: service (which upstream), reason (timeout / http_error / network),
+// upstream_status (HTTP status when the upstream answered), upstream_code (axios / node error code).
+const UPSTREAM_ERROR_METRIC = 'gateway.upstream_error';
+
+// axios / node error codes that mean "no answer in time"
+const TIMEOUT_CODES = ['ECONNABORTED', 'ETIMEDOUT', 'ERR_CANCELED'];
+
+function isAxiosError(error) {
+  return Boolean(error && (error.isAxiosError === true || error.name === 'AxiosError'));
+}
+
+function summarizeResponseData(data) {
+  if (data == null) {
+    return '';
+  }
+  if (typeof data === 'string') {
+    return data.slice(0, 200);
+  }
+  if (typeof data.error === 'string') {
+    return data.error.slice(0, 200);
+  }
+  if (data.error && data.error.message) {
+    return String(data.error.message).slice(0, 200);
+  }
+  if (data.message) {
+    return String(data.message).slice(0, 200);
+  }
+  try {
+    return JSON.stringify(data).slice(0, 200);
+  } catch (e) {
+    return '';
+  }
+}
+
+/**
+ * One compact line describing an axios failure: method, url, status / code and a
+ * short summary of the response body. Never dumps the request config (headers, tokens, body).
+ */
+function formatAxiosError(error) {
+  const method = ((error.config && error.config.method) || '?').toUpperCase();
+  const url = (error.config && error.config.url) || '?';
+  const status = (error.response && error.response.status) || error.code || '?';
+  const statusText = (error.response && error.response.statusText) || '';
+  const detail = summarizeResponseData(error.response && error.response.data);
+  const statusPart = statusText ? `${status} ${statusText}` : String(status);
+  return `Axios ${method} ${url} → ${statusPart}${detail ? ` — ${detail}` : ''}`;
+}
+
+function isUpstreamTimeout(error) {
+  if (TIMEOUT_CODES.includes(error.code)) {
+    return true;
+  }
+  const status = error.response && error.response.status;
+  return status === 504 || status === 408;
+}
+
+function getUpstreamReason(error) {
+  if (isUpstreamTimeout(error)) {
+    return 'timeout';
+  }
+  if (error.response && error.response.status) {
+    return 'http_error';
+  }
+  return 'network';
+}
+
+/**
+ * Count an upstream failure in Sentry instead of reporting it as an exception:
+ * these failures are operational (the upstream is slow or down), not bugs, and
+ * a counter is what we need to watch them.
+ * Attribute values must be primitives for Sentry.
+ */
+function countUpstreamError(service, error, reason) {
+  const attributes = {
+    service,
+    reason,
+    upstream_status: (error.response && error.response.status) || 0,
+    upstream_code: error.code || '',
+  };
+  try {
+    Sentry.metrics.count(UPSTREAM_ERROR_METRIC, 1, { attributes });
+  } catch (e) {
+    // counting must never break the request handling
+  }
+}
+
+/**
+ * Convert an axios failure on a call to an upstream service into a clean
+ * 504 (timeout) or 502 (any other upstream failure) error, and count it in Sentry.
+ * Non-axios errors are returned untouched: they are real bugs and must still reach Sentry.
+ *
+ * @param {string} service short identifier of the upstream (e.g. 'openai_ask'), used as metric attribute
+ * @param {Error} error the error thrown by axios
+ * @param {string} [serviceLabel] human readable name used in the message sent back to the client
+ * @returns {Error} the error to throw
+ */
+function mapUpstreamError(service, error, serviceLabel = 'Upstream service') {
+  if (!isAxiosError(error)) {
+    return error;
+  }
+  const reason = getUpstreamReason(error);
+  countUpstreamError(service, error, reason);
+  const upstream = formatAxiosError(error);
+  if (reason === 'timeout') {
+    return new GatewayTimeoutError(`${serviceLabel} did not answer in time`, upstream);
+  }
+  if (reason === 'http_error') {
+    return new BadGatewayError(`${serviceLabel} returned an error`, upstream);
+  }
+  return new BadGatewayError(`${serviceLabel} is unreachable`, upstream);
+}
+
+module.exports = {
+  UPSTREAM_ERROR_METRIC,
+  isAxiosError,
+  summarizeResponseData,
+  formatAxiosError,
+  isUpstreamTimeout,
+  getUpstreamReason,
+  countUpstreamError,
+  mapUpstreamError,
+};

--- a/test/core/api/openai/openai.controller.test.js
+++ b/test/core/api/openai/openai.controller.test.js
@@ -154,6 +154,95 @@ describe('POST /openai/ask', () => {
       api_response_id: null,
     });
   });
+  describe('when the AI service fails', () => {
+    beforeEach(async () => {
+      await TEST_DATABASE_INSTANCE.t_account.update(
+        {
+          id: 'b2d23f66-487d-493f-8acb-9c8adb400def',
+        },
+        {
+          status: 'active',
+        },
+      );
+    });
+    afterEach(() => {
+      delete process.env.OPEN_AI_ASK_TIMEOUT_MS;
+    });
+
+    async function ask() {
+      return request(TEST_BACKEND_APP)
+        .post('/openai/ask')
+        .set('Accept', 'application/json')
+        .set('Authorization', configTest.jwtAccessTokenInstance)
+        .send({
+          question: 'Allume la lumière de la cuisine',
+        })
+        .expect('Content-Type', /json/);
+    }
+
+    it('should return 504 when the AI service answers 504', async () => {
+      nock(process.env.OPEN_AI_ASK_API_URL, { encodedQueryParams: true })
+        .post('/', (body) => true)
+        .reply(504, 'Scaleway request timed out');
+      const response = await ask();
+      expect(response.status).to.equal(504);
+      expect(response.body).to.deep.equal({
+        status: 504,
+        error_code: 'GATEWAY_TIMEOUT',
+        error_message: 'AI service did not answer in time',
+      });
+      const aiUsages = await TEST_DATABASE_INSTANCE.t_ai_usage.find({});
+      expect(aiUsages).to.have.lengthOf(0);
+    });
+
+    it('should return 504 when the AI service does not answer before the gateway timeout', async () => {
+      process.env.OPEN_AI_ASK_TIMEOUT_MS = '50';
+      nock(process.env.OPEN_AI_ASK_API_URL, { encodedQueryParams: true })
+        .post('/', (body) => true)
+        .delay(500)
+        .reply(200, { type: 'TURN_ON' });
+      const response = await ask();
+      expect(response.status).to.equal(504);
+      expect(response.body.error_code).to.equal('GATEWAY_TIMEOUT');
+      nock.cleanAll();
+    });
+
+    it('should return 502 when the AI service answers 500', async () => {
+      nock(process.env.OPEN_AI_ASK_API_URL, { encodedQueryParams: true })
+        .post('/', (body) => true)
+        .reply(500, { error: 'Internal Server Error' });
+      const response = await ask();
+      expect(response.status).to.equal(502);
+      expect(response.body).to.deep.equal({
+        status: 502,
+        error_code: 'BAD_GATEWAY',
+        error_message: 'AI service returned an error',
+      });
+    });
+
+    it('should return 502 when the AI service rejects the request (400)', async () => {
+      nock(process.env.OPEN_AI_ASK_API_URL, { encodedQueryParams: true })
+        .post('/', (body) => true)
+        .reply(400, { error: { message: 'invalid request' } });
+      const response = await ask();
+      expect(response.status).to.equal(502);
+      expect(response.body.error_code).to.equal('BAD_GATEWAY');
+    });
+
+    it('should return 502 when the AI service is unreachable', async () => {
+      nock(process.env.OPEN_AI_ASK_API_URL, { encodedQueryParams: true })
+        .post('/', (body) => true)
+        .replyWithError({ code: 'ECONNREFUSED', message: 'connect ECONNREFUSED' });
+      const response = await ask();
+      expect(response.status).to.equal(502);
+      expect(response.body).to.deep.equal({
+        status: 502,
+        error_code: 'BAD_GATEWAY',
+        error_message: 'AI service is unreachable',
+      });
+    });
+  });
+
   it('should send question to AI when trialing', async () => {
     nock(process.env.OPEN_AI_ASK_API_URL, { encodedQueryParams: true })
       .post('/', (body) => true)

--- a/test/core/middleware/errorMiddleware.test.js
+++ b/test/core/middleware/errorMiddleware.test.js
@@ -9,6 +9,8 @@ const {
   BadRequestError,
   TooManyRequestsError,
   PaymentRequiredError,
+  BadGatewayError,
+  GatewayTimeoutError,
 } = require('../../../core/common/error');
 
 function createMockRes() {
@@ -129,6 +131,41 @@ describe('errorMiddleware', () => {
     expect(logger.calls.warn[0][0]).to.equal('402 card declined POST /accounts/subscribe user=u1');
     expect(res.statusCode).to.equal(402);
     expect(res.body.error_code).to.equal('PAYMENT_REQUIRED');
+  });
+
+  it('should warn once for upstream errors with the upstream detail and answer 502 / 504', () => {
+    const logger = createLoggerSpy();
+    const middleware = getErrorMiddleware(logger);
+    const req = { method: 'POST', route: { path: '/openai/ask' } };
+
+    const res = createMockRes();
+    middleware(
+      new GatewayTimeoutError('AI service did not answer in time', 'Axios POST https://ai.example.com → 504'),
+      req,
+      res,
+      () => {},
+    );
+    expect(logger.calls.warn).to.have.length(1);
+    expect(logger.calls.warn[0][0]).to.equal(
+      '504 AI service did not answer in time (Axios POST https://ai.example.com → 504) POST /openai/ask user=—',
+    );
+    expect(logger.calls.error).to.have.length(0);
+    expect(res.statusCode).to.equal(504);
+    expect(res.body).to.deep.equal({
+      status: 504,
+      error_code: 'GATEWAY_TIMEOUT',
+      error_message: 'AI service did not answer in time',
+    });
+
+    const res2 = createMockRes();
+    middleware(new BadGatewayError('AI service is unreachable'), req, res2, () => {});
+    expect(logger.calls.warn[1][0]).to.equal('502 AI service is unreachable POST /openai/ask user=—');
+    expect(res2.statusCode).to.equal(502);
+    expect(res2.body).to.deep.equal({
+      status: 502,
+      error_code: 'BAD_GATEWAY',
+      error_message: 'AI service is unreachable',
+    });
   });
 
   it('should warn for generic statusCode 404 errors', () => {
@@ -323,6 +360,13 @@ describe('shouldReportErrorToSentry', () => {
     expect(shouldReportErrorToSentry(new UnauthorizedError())).to.equal(false);
     expect(shouldReportErrorToSentry(new BadRequestError('Bad'))).to.equal(false);
     expect(shouldReportErrorToSentry(new NotFoundError('Nope'))).to.equal(false);
+  });
+
+  it('should not report expected upstream errors (502 / 504), they are counted as metrics', () => {
+    expect(shouldReportErrorToSentry(new BadGatewayError('AI service returned an error'))).to.equal(false);
+    expect(shouldReportErrorToSentry(new GatewayTimeoutError('AI service did not answer in time'))).to.equal(false);
+    expect(getErrorMiddleware.isExpectedUpstreamError(new GatewayTimeoutError())).to.equal(true);
+    expect(getErrorMiddleware.isExpectedUpstreamError(new Error('boom'))).to.equal(false);
   });
 
   it('should not report generic 404 errors coming from third-party middlewares', () => {

--- a/test/core/service/sentry.smoke.js
+++ b/test/core/service/sentry.smoke.js
@@ -26,6 +26,7 @@ sentryService.init({
 const express = require('express');
 const { ValidationError, UnauthorizedError, NotFoundError } = require('../../../core/common/error');
 const ErrorMiddleware = require('../../../core/middleware/errorMiddleware');
+const { mapUpstreamError, UPSTREAM_ERROR_METRIC } = require('../../../core/service/upstreamError');
 
 const silentLogger = { debug() {}, info() {}, warn() {}, error() {} };
 
@@ -44,6 +45,28 @@ function exceptionMessagesFromEnvelope(envelope) {
     .flatMap((item) => item.exception.values.map((exception) => exception.value));
 }
 
+function metricsFromEnvelope(envelope) {
+  return envelope
+    .split('\n')
+    .map((line) => {
+      try {
+        return JSON.parse(line);
+      } catch (e) {
+        return null;
+      }
+    })
+    .filter((item) => item && Array.isArray(item.items))
+    .flatMap((item) => item.items)
+    .filter((metric) => metric.name === UPSTREAM_ERROR_METRIC)
+    .map((metric) => ({
+      type: metric.type,
+      value: metric.value,
+      service: metric.attributes.service && metric.attributes.service.value,
+      reason: metric.attributes.reason && metric.attributes.reason.value,
+      upstream_status: metric.attributes.upstream_status && metric.attributes.upstream_status.value,
+    }));
+}
+
 (async () => {
   const app = express();
   app.get('/validation-error', () => {
@@ -58,6 +81,15 @@ function exceptionMessagesFromEnvelope(envelope) {
   app.get('/unexpected', () => {
     throw new Error('unexpected boom');
   });
+  app.get('/upstream-timeout', () => {
+    // what axios throws when the AI service answers 504
+    const axiosError = new Error('Request failed with status code 504');
+    axiosError.isAxiosError = true;
+    axiosError.code = 'ERR_BAD_RESPONSE';
+    axiosError.config = { method: 'post', url: 'https://ai.example.com' };
+    axiosError.response = { status: 504, statusText: 'Gateway Timeout', data: 'timed out' };
+    throw mapUpstreamError('openai_ask', axiosError, 'AI service');
+  });
   Sentry.setupExpressErrorHandler(app);
   app.use(ErrorMiddleware(silentLogger));
 
@@ -65,7 +97,7 @@ function exceptionMessagesFromEnvelope(envelope) {
   const { port } = server.address();
   const statuses = {};
   // eslint-disable-next-line no-restricted-syntax
-  for (const route of ['/validation-error', '/unauthorized', '/not-found', '/unexpected']) {
+  for (const route of ['/validation-error', '/unauthorized', '/not-found', '/unexpected', '/upstream-timeout']) {
     // eslint-disable-next-line no-await-in-loop
     const response = await fetch(`http://127.0.0.1:${port}${route}`);
     statuses[route] = response.status;
@@ -77,6 +109,7 @@ function exceptionMessagesFromEnvelope(envelope) {
     JSON.stringify({
       statuses,
       captured: captured.flatMap(exceptionMessagesFromEnvelope),
+      metrics: captured.flatMap(metricsFromEnvelope),
     }),
   );
   await Sentry.close(1000);

--- a/test/core/service/sentry.test.js
+++ b/test/core/service/sentry.test.js
@@ -20,15 +20,20 @@ describe('sentry service', function sentryService() {
   this.timeout(30000);
 
   it('should only report unexpected errors to Sentry, not expected client errors', async () => {
-    const { statuses, captured } = await runSmokeScript();
+    const { statuses, captured, metrics } = await runSmokeScript();
     // the error middleware still answers every request
     expect(statuses).to.deep.equal({
       '/validation-error': 422,
       '/unauthorized': 401,
       '/not-found': 404,
       '/unexpected': 500,
+      '/upstream-timeout': 504,
     });
-    // only the unexpected error reached Sentry
+    // only the unexpected error reached Sentry as an exception
     expect(captured).to.deep.equal(['unexpected boom']);
+    // the upstream failure was counted as a metric instead
+    expect(metrics).to.deep.equal([
+      { type: 'counter', value: 1, service: 'openai_ask', reason: 'timeout', upstream_status: 504 },
+    ]);
   });
 });

--- a/test/core/service/upstreamError.test.js
+++ b/test/core/service/upstreamError.test.js
@@ -1,0 +1,147 @@
+const { expect } = require('chai');
+const Sentry = require('@sentry/node');
+const {
+  UPSTREAM_ERROR_METRIC,
+  mapUpstreamError,
+  getUpstreamReason,
+  formatAxiosError,
+} = require('../../../core/service/upstreamError');
+const { BadGatewayError, GatewayTimeoutError } = require('../../../core/common/error');
+
+function axiosError({ code, status, statusText, data } = {}) {
+  const error = new Error(status ? `Request failed with status code ${status}` : code);
+  error.isAxiosError = true;
+  error.name = 'AxiosError';
+  error.code = code;
+  error.config = {
+    method: 'post',
+    url: 'https://open-ai.example.com',
+    data: '{"question":"secret question"}',
+    headers: { authorization: 'Bearer secret-token' },
+  };
+  if (status) {
+    error.response = { status, statusText, data };
+  }
+  return error;
+}
+
+describe('upstreamError service', () => {
+  let counted;
+  let originalCount;
+
+  beforeEach(() => {
+    counted = [];
+    originalCount = Sentry.metrics.count;
+    Sentry.metrics.count = (name, value, options) => counted.push({ name, value, options });
+  });
+
+  afterEach(() => {
+    Sentry.metrics.count = originalCount;
+  });
+
+  it('should map an upstream 504 to a GatewayTimeoutError and count it', () => {
+    const error = mapUpstreamError(
+      'openai_ask',
+      axiosError({ code: 'ERR_BAD_RESPONSE', status: 504, statusText: 'Gateway Timeout', data: 'timed out' }),
+      'AI service',
+    );
+    expect(error).to.be.instanceOf(GatewayTimeoutError);
+    expect(error.getStatus()).to.equal(504);
+    expect(error.jsonError()).to.deep.equal({
+      status: 504,
+      error_code: 'GATEWAY_TIMEOUT',
+      error_message: 'AI service did not answer in time',
+    });
+    expect(error.upstream).to.equal('Axios POST https://open-ai.example.com → 504 Gateway Timeout — timed out');
+    expect(counted).to.deep.equal([
+      {
+        name: UPSTREAM_ERROR_METRIC,
+        value: 1,
+        options: {
+          attributes: {
+            service: 'openai_ask',
+            reason: 'timeout',
+            upstream_status: 504,
+            upstream_code: 'ERR_BAD_RESPONSE',
+          },
+        },
+      },
+    ]);
+  });
+
+  it('should map a client-side timeout (ECONNABORTED / ETIMEDOUT) to a GatewayTimeoutError', () => {
+    ['ECONNABORTED', 'ETIMEDOUT'].forEach((code) => {
+      const error = mapUpstreamError('openai_ask', axiosError({ code }));
+      expect(error).to.be.instanceOf(GatewayTimeoutError);
+      expect(error.errorMessage).to.equal('Upstream service did not answer in time');
+    });
+    expect(counted.map((c) => c.options.attributes)).to.deep.equal([
+      { service: 'openai_ask', reason: 'timeout', upstream_status: 0, upstream_code: 'ECONNABORTED' },
+      { service: 'openai_ask', reason: 'timeout', upstream_status: 0, upstream_code: 'ETIMEDOUT' },
+    ]);
+  });
+
+  it('should map an upstream HTTP error (5xx or 4xx) to a BadGatewayError', () => {
+    [500, 502, 503, 400, 429].forEach((status) => {
+      const error = mapUpstreamError('openai_ask', axiosError({ code: 'ERR_BAD_RESPONSE', status }), 'AI service');
+      expect(error).to.be.instanceOf(BadGatewayError);
+      expect(error.getStatus()).to.equal(502);
+      expect(error.jsonError()).to.deep.equal({
+        status: 502,
+        error_code: 'BAD_GATEWAY',
+        error_message: 'AI service returned an error',
+      });
+    });
+    expect(counted).to.have.lengthOf(5);
+    expect(counted[0].options.attributes).to.deep.equal({
+      service: 'openai_ask',
+      reason: 'http_error',
+      upstream_status: 500,
+      upstream_code: 'ERR_BAD_RESPONSE',
+    });
+  });
+
+  it('should map a network error (no response) to a BadGatewayError', () => {
+    const error = mapUpstreamError('openai_ask', axiosError({ code: 'ECONNREFUSED' }), 'AI service');
+    expect(error).to.be.instanceOf(BadGatewayError);
+    expect(error.errorMessage).to.equal('AI service is unreachable');
+    expect(counted[0].options.attributes).to.deep.equal({
+      service: 'openai_ask',
+      reason: 'network',
+      upstream_status: 0,
+      upstream_code: 'ECONNREFUSED',
+    });
+  });
+
+  it('should never put the request body or the authorization header in the upstream detail', () => {
+    const error = mapUpstreamError('openai_ask', axiosError({ code: 'ERR_BAD_RESPONSE', status: 500 }));
+    expect(error.upstream).to.not.include('secret');
+  });
+
+  it('should return non-axios errors untouched and not count them', () => {
+    const bug = new TypeError("Cannot read property 'x' of undefined");
+    expect(mapUpstreamError('openai_ask', bug)).to.equal(bug);
+    expect(mapUpstreamError('openai_ask', null)).to.equal(null);
+    expect(counted).to.have.lengthOf(0);
+  });
+
+  it('should not fail when the Sentry counter throws', () => {
+    Sentry.metrics.count = () => {
+      throw new Error('sentry is broken');
+    };
+    const error = mapUpstreamError('openai_ask', axiosError({ code: 'ERR_BAD_RESPONSE', status: 504 }));
+    expect(error).to.be.instanceOf(GatewayTimeoutError);
+  });
+
+  it('should classify reasons', () => {
+    expect(getUpstreamReason(axiosError({ code: 'ERR_BAD_RESPONSE', status: 408 }))).to.equal('timeout');
+    expect(getUpstreamReason(axiosError({ code: 'ERR_BAD_RESPONSE', status: 503 }))).to.equal('http_error');
+    expect(getUpstreamReason(axiosError({ code: 'ENOTFOUND' }))).to.equal('network');
+  });
+
+  it('should format an axios error without a response', () => {
+    expect(formatAxiosError(axiosError({ code: 'ECONNREFUSED' }))).to.equal(
+      'Axios POST https://open-ai.example.com → ECONNREFUSED',
+    );
+  });
+});


### PR DESCRIPTION
## Context

Sentry issue [GLADYS-GATEWAY-DT](https://gladys-assistant.sentry.io/issues/GLADYS-GATEWAY-DT): `AxiosError: Request failed with status code 504` on `POST /openai/ask`, 384 occurrences since May 2026. Over the last 90 days the same issue groups 92 × 504, 10 × 400 and 3 × 500 coming from the AI service behind `OPEN_AI_ASK_API_URL`.

Today the gateway answers a generic `500 SERVER_ERROR` to the Gladys instance and each failure is reported to Sentry as an exception, although it is an upstream problem, not a gateway bug. The outgoing axios call also had no timeout: the gateway waited as long as the upstream proxy did.

## Changes

- **`core/common/error.js`**: new `BadGatewayError` (502, `BAD_GATEWAY`) and `GatewayTimeoutError` (504, `GATEWAY_TIMEOUT`), same shape as the other error classes, with an `upstream` field holding a compact description of the upstream failure (logging only).
- **`core/service/upstreamError.js`** (new): `mapUpstreamError(service, axiosError, label)` maps an axios failure to
  - 504 for a client-side timeout (`ECONNABORTED`, `ETIMEDOUT`) or an upstream 504/408,
  - 502 for any other upstream HTTP error (5xx or 4xx) or an unreachable upstream (`ECONNREFUSED`, `ENOTFOUND`, …),
  and counts it with the Sentry metric `gateway.upstream_error` (attributes `service`, `reason`, `upstream_status`, `upstream_code`) instead of capturing an exception. Non-axios errors are returned untouched so real bugs still reach Sentry. The axios formatting helpers (`isAxiosError`, `formatAxiosError`, …) move here from the error middleware, unchanged.
- **`core/api/openai/openai.controller.js`**: wraps the AI call, maps the error, and sets a client-side timeout, `OPEN_AI_ASK_TIMEOUT_MS` (default 60 s), so a hung upstream no longer holds a gateway connection forever. No usage row is saved when the call fails (unchanged).
- **`core/middleware/errorMiddleware.js`**: answers the mapped 502/504 with the error's JSON body, logs one `warn` line with the upstream detail (never the request body or headers), and excludes these errors from Sentry via `shouldReportErrorToSentry`.

Response sent to the instance, e.g. on a timeout:

```json
{ "status": 504, "error_code": "GATEWAY_TIMEOUT", "error_message": "AI service did not answer in time" }
```

## Tests

- `test/core/service/upstreamError.test.js` (new): mapping of every reason, metric attributes, no secret in the upstream detail, non-axios passthrough, counter failure tolerance.
- `test/core/api/openai/openai.controller.test.js`: integration cases for upstream 504, gateway timeout, upstream 500, upstream 400, unreachable upstream.
- `test/core/middleware/errorMiddleware.test.js`: log line and response for the new errors, Sentry exclusion.
- `test/core/service/sentry.smoke.js`: an upstream failure now answers 504, is not captured as an exception, and produces one `gateway.upstream_error` counter in the Sentry envelope.

Run locally: lint, prettier and the affected test files pass (47 tests). The full suite has 18 failures that also fail on `master` without this change: S3 backup/camera and Google Home tests that need the CI secrets.

## Notes for the reviewer

- The upstream 504 body seen in production is `Scaleway request timed out`: the timeout is enforced by the Scaleway gateway in front of the AI service, not by this gateway. Health and timeout of that service should be checked on the Scaleway side (function/container timeout and the model latency); this PR only makes the gateway behave correctly when it happens.
- The 60 s default is a guess at a safe upper bound for a chat completion; adjust `OPEN_AI_ASK_TIMEOUT_MS` in production if legit answers take longer.
- The rate-limit credit consumed by `openAIAuthAndRateLimit` is not refunded on an upstream failure (unchanged). Could be a follow-up.
- A Sentry alert on `gateway.upstream_error` (e.g. `reason:timeout`) replaces the issue-based alerting; the issue itself is referenced with `Fixes GLADYS-GATEWAY-DT` in the commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B7yd7HLMDGZkGhDpLjTvKp

---
_Generated by [Claude Code](https://claude.ai/code/session_01B7yd7HLMDGZkGhDpLjTvKp)_