### PR TITLE
Sentry: attach the authenticated user id (never the email) to reported errors

### DIFF
--- a/core/api/routes.js
+++ b/core/api/routes.js
@@ -1,5 +1,6 @@
 const bodyParser = require('body-parser');
 const Sentry = require('@sentry/node');
+const { setUserErrorHandler } = require('../service/sentry');
 const asyncMiddleware = require('../middleware/asyncMiddleware');
 const { NotFoundError } = require('../common/error');
 
@@ -556,6 +557,8 @@ module.exports.load = function Routes(app, io, controllers, middlewares) {
 
   // Captures unexpected errors to Sentry (the filter is configured on the Express
   // integration in core/service/sentry.js) and forwards them to the error middleware.
+  // Only the authenticated user id is attached to the event, never the email.
+  app.use(setUserErrorHandler);
   Sentry.setupExpressErrorHandler(app);
 
   // error

--- a/core/service/beforeSendSentry.js
+++ b/core/service/beforeSendSentry.js
@@ -4,7 +4,7 @@ const omitDeep = require('omit-deep');
 // stripped from the event before it leaves the server, wherever it appears
 // (request body, headers, extra context...)
 const PROPERTIES_TO_OMIT = [
-  // personal data
+  // personal data (the user id alone is kept so an issue can be linked to an account)
   'email',
   // credentials & tokens
   'password',

--- a/core/service/sentry.js
+++ b/core/service/sentry.js
@@ -21,14 +21,15 @@ function init(overrides = {}) {
       // are already handled by the error middleware and would only pollute Sentry.
       // This is read back by the error handler registered with `setupExpressErrorHandler`.
       Sentry.expressIntegration({ shouldHandleError: shouldReportErrorToSentry }),
-      // headers (Authorization, Stripe signature) and cookies are never sent to Sentry,
-      // the body is kept for debugging but scrubbed by beforeSendSentry
+      // headers (Authorization, Stripe signature), cookies and the client IP are never
+      // sent to Sentry, the body is kept for debugging but scrubbed by beforeSendSentry.
+      // The user is not read from the request by the SDK: only the user id is attached,
+      // by `setUserErrorHandler`.
       Sentry.requestDataIntegration({
         include: {
           cookies: false,
           headers: false,
           ip: false,
-          user: false,
           data: true,
           query_string: true,
           url: true,
@@ -39,4 +40,17 @@ function init(overrides = {}) {
   });
 }
 
-module.exports = { init };
+/**
+ * Express error handler to register right before `Sentry.setupExpressErrorHandler`:
+ * attaches the id of the authenticated user (and only the id, never the email or
+ * the rest of the profile) to the Sentry scope of the current request, so an issue
+ * can still be linked to an account without sending personal data.
+ */
+function setUserErrorHandler(error, req, res, next) {
+  if (req.user && req.user.id) {
+    Sentry.setUser({ id: req.user.id });
+  }
+  next(error);
+}
+
+module.exports = { init, setUserErrorHandler };

--- a/test/core/service/beforeSendSentry.test.js
+++ b/test/core/service/beforeSendSentry.test.js
@@ -33,6 +33,11 @@ describe('beforeSendSentry', () => {
     expect(beforeSendSentry({ request: { url: 'not a url at all' } })).to.not.equal(null);
   });
 
+  it('should keep the user id but never the email', () => {
+    const event = { user: { id: 'user-id', email: 'tony.stark@gladysassistant.com' }, message: 'boom' };
+    expect(beforeSendSentry(event)).to.deep.equal({ user: { id: 'user-id' }, message: 'boom' });
+  });
+
   it('should keep events without a request', () => {
     expect(beforeSendSentry({ message: 'boom' })).to.deep.equal({ message: 'boom' });
   });

--- a/test/core/service/sentry.smoke.js
+++ b/test/core/service/sentry.smoke.js
@@ -3,7 +3,8 @@
  * the SDK must be initialized before Express is loaded, and the main mocha
  * process boots the whole gateway (and Express) without a Sentry client.
  *
- * Prints, as JSON on stdout, the exception messages that reached the transport.
+ * Prints, as JSON on stdout, the exception messages (and the user attached to them)
+ * that reached the transport.
  */
 process.env.SENTRY_DSN = 'https://public@example.ingest.sentry.io/1';
 
@@ -26,11 +27,12 @@ sentryService.init({
 const express = require('express');
 const { ValidationError, UnauthorizedError, NotFoundError } = require('../../../core/common/error');
 const ErrorMiddleware = require('../../../core/middleware/errorMiddleware');
+const asyncMiddleware = require('../../../core/middleware/asyncMiddleware');
 const { mapUpstreamError, UPSTREAM_ERROR_METRIC } = require('../../../core/service/upstreamError');
 
 const silentLogger = { debug() {}, info() {}, warn() {}, error() {} };
 
-function exceptionMessagesFromEnvelope(envelope) {
+function exceptionEventsFromEnvelope(envelope) {
   // an envelope is a list of JSON documents separated by newlines
   return envelope
     .split('\n')
@@ -41,8 +43,17 @@ function exceptionMessagesFromEnvelope(envelope) {
         return null;
       }
     })
-    .filter((item) => item && item.exception && item.exception.values)
-    .flatMap((item) => item.exception.values.map((exception) => exception.value));
+    .filter((item) => item && item.exception && item.exception.values);
+}
+
+function exceptionMessagesFromEnvelope(envelope) {
+  return exceptionEventsFromEnvelope(envelope).flatMap((item) =>
+    item.exception.values.map((exception) => exception.value),
+  );
+}
+
+function usersFromEnvelope(envelope) {
+  return exceptionEventsFromEnvelope(envelope).map((item) => item.user || null);
 }
 
 function metricsFromEnvelope(envelope) {
@@ -81,6 +92,14 @@ function metricsFromEnvelope(envelope) {
   app.get('/unexpected', () => {
     throw new Error('unexpected boom');
   });
+  // what the auth middlewares (and openApiApiKeyAuth, with the whole profile) set
+  const fakeAuth = asyncMiddleware(async (req, res, next) => {
+    req.user = { id: 'user-id', email: 'tony.stark@gladysassistant.com', name: 'Tony' };
+    next();
+  });
+  app.get('/unexpected-authenticated', fakeAuth, () => {
+    throw new Error('unexpected authenticated boom');
+  });
   app.get('/upstream-timeout', () => {
     // what axios throws when the AI service answers 504
     const axiosError = new Error('Request failed with status code 504');
@@ -90,6 +109,7 @@ function metricsFromEnvelope(envelope) {
     axiosError.response = { status: 504, statusText: 'Gateway Timeout', data: 'timed out' };
     throw mapUpstreamError('openai_ask', axiosError, 'AI service');
   });
+  app.use(sentryService.setUserErrorHandler);
   Sentry.setupExpressErrorHandler(app);
   app.use(ErrorMiddleware(silentLogger));
 
@@ -97,7 +117,14 @@ function metricsFromEnvelope(envelope) {
   const { port } = server.address();
   const statuses = {};
   // eslint-disable-next-line no-restricted-syntax
-  for (const route of ['/validation-error', '/unauthorized', '/not-found', '/unexpected', '/upstream-timeout']) {
+  for (const route of [
+    '/validation-error',
+    '/unauthorized',
+    '/not-found',
+    '/unexpected',
+    '/unexpected-authenticated',
+    '/upstream-timeout',
+  ]) {
     // eslint-disable-next-line no-await-in-loop
     const response = await fetch(`http://127.0.0.1:${port}${route}`);
     statuses[route] = response.status;
@@ -109,6 +136,7 @@ function metricsFromEnvelope(envelope) {
     JSON.stringify({
       statuses,
       captured: captured.flatMap(exceptionMessagesFromEnvelope),
+      users: captured.flatMap(usersFromEnvelope),
       metrics: captured.flatMap(metricsFromEnvelope),
     }),
   );

--- a/test/core/service/sentry.test.js
+++ b/test/core/service/sentry.test.js
@@ -20,17 +20,20 @@ describe('sentry service', function sentryService() {
   this.timeout(30000);
 
   it('should only report unexpected errors to Sentry, not expected client errors', async () => {
-    const { statuses, captured, metrics } = await runSmokeScript();
+    const { statuses, captured, users, metrics } = await runSmokeScript();
     // the error middleware still answers every request
     expect(statuses).to.deep.equal({
       '/validation-error': 422,
       '/unauthorized': 401,
       '/not-found': 404,
       '/unexpected': 500,
+      '/unexpected-authenticated': 500,
       '/upstream-timeout': 504,
     });
-    // only the unexpected error reached Sentry as an exception
-    expect(captured).to.deep.equal(['unexpected boom']);
+    // only the unexpected errors reached Sentry as exceptions
+    expect(captured).to.deep.equal(['unexpected boom', 'unexpected authenticated boom']);
+    // the authenticated user is identified by its id only (no email, no IP address)
+    expect(users).to.deep.equal([null, { id: 'user-id' }]);
     // the upstream failure was counted as a metric instead
     expect(metrics).to.deep.equal([
       { type: 'counter', value: 1, service: 'openai_ask', reason: 'timeout', upstream_status: 504 },


### PR DESCRIPTION
## Why

Since the Sentry SDK upgrade (#213), errors reported to Sentry carry no user anymore: with SDK v10 the request data integration no longer reads `req.user` at all (the `user: false` include option was a no-op), so an issue could not be linked to an account. We still don't want to send personal data, so the compromise agreed on is to keep the **user id only**, never the email.

## What

- `core/service/sentry.js`: new `setUserErrorHandler` Express error handler that calls `Sentry.setUser({ id: req.user.id })` on the current request scope when the request is authenticated, then forwards the error. Only the id is attached: the email and the rest of the profile (which `openApiApiKeyAuth` puts in `req.user`) are never read.
- `core/api/routes.js`: register it right before `Sentry.setupExpressErrorHandler(app)`.
- `core/service/sentry.js`: drop the no-op `user: false` include and document the behaviour; `ip: false` and `sendDefaultPii: false` are unchanged, so no IP address is sent either.
- `beforeSendSentry` keeps stripping `email` everywhere as a second line of defence.

## Tests

- Sentry smoke test: new `/unexpected-authenticated` route with a fake auth middleware setting a full `req.user` (id, email, name); the captured event has `user: { id: 'user-id' }` and the unauthenticated event has no user.
- `beforeSendSentry` test: an event with `user: { id, email }` is sent with the id only.

`npm run eslint`, `prettier --check` and the Sentry / beforeSendSentry test suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018RegQMiXaWBPooUodENbe9

---
_Generated by [Claude Code](https://claude.ai/code/session_018RegQMiXaWBPooUodENbe9)_