### PR TITLE
Account: return unknown plan on GET /accounts/plan when the account has no Stripe subscription

### DIFF
--- a/core/api/account/account.model.js
+++ b/core/api/account/account.model.js
@@ -517,6 +517,16 @@ module.exports = function AccountModel(
       { fields: ['id', 'stripe_customer_id', 'stripe_subscription_id'] },
     );
 
+    // An account without a Stripe subscription (never subscribed, or its subscription
+    // was never linked) has no plan to look up: calling Stripe with a null id throws
+    // and would turn the dashboard request into a 500.
+    if (!account.stripe_subscription_id) {
+      logger.warn(
+        `getUserCurrentPlan: account ${account.id} (user ${userWithAccount.id}) has no stripe_subscription_id, returning unknown plan`,
+      );
+      return { plan: 'unknown', product: 'unknown' };
+    }
+
     const subscription = await stripeService.getSubscription(account.stripe_subscription_id);
     return getPlanAndProductFromSubscription(subscription);
   }

--- a/core/api/account/account.model.js
+++ b/core/api/account/account.model.js
@@ -517,13 +517,10 @@ module.exports = function AccountModel(
       { fields: ['id', 'stripe_customer_id', 'stripe_subscription_id'] },
     );
 
-    // An account without a Stripe subscription (never subscribed, or its subscription
-    // was never linked) has no plan to look up: calling Stripe with a null id throws
-    // and would turn the dashboard request into a 500.
+    // Internal / tester accounts have no Stripe subscription: there is no plan to
+    // look up, and calling Stripe with a null id throws (500 on the dashboard).
     if (!account.stripe_subscription_id) {
-      logger.warn(
-        `getUserCurrentPlan: account ${account.id} (user ${userWithAccount.id}) has no stripe_subscription_id, returning unknown plan`,
-      );
+      logger.info(`getUserCurrentPlan: account ${account.id} has no stripe_subscription_id, returning unknown plan`);
       return { plan: 'unknown', product: 'unknown' };
     }
 

--- a/test/core/api/account/account.controller.test.js
+++ b/test/core/api/account/account.controller.test.js
@@ -328,6 +328,22 @@ describe('GET /accounts/plan', () => {
       .expect(200);
     expect(response.body).to.deep.equal({ plan: 'unknown', product: 'unknown' });
   });
+  it('should return unknown plan without calling Stripe when account has no subscription', async () => {
+    await TEST_DATABASE_INSTANCE.t_account.update(
+      {
+        id: 'b2d23f66-487d-493f-8acb-9c8adb400def',
+      },
+      { stripe_subscription_id: null },
+    );
+    // No Stripe mock on purpose: the Stripe SDK throws on a null id, so a 200
+    // here proves Stripe was never called.
+    const response = await request(TEST_BACKEND_APP)
+      .get('/accounts/plan')
+      .set('Accept', 'application/json')
+      .set('Authorization', configTest.jwtAccessTokenDashboard)
+      .expect(200);
+    expect(response.body).to.deep.equal({ plan: 'unknown', product: 'unknown' });
+  });
 });
 
 describe('POST /accounts/upgrade-to-yearly', () => {


### PR DESCRIPTION
## Bug

Sentry issue [GLADYS-GATEWAY-DD](https://gladys-assistant.sentry.io/issues/GLADYS-GATEWAY-DD): `Error: Stripe: Argument "subscriptionExposedId" must be a string, but got: null` on `GET /accounts/plan`. 16 occurrences since January, 1 user, latest at 2026-09-04 12:05 UTC (only event since the redeploy).

`getUserCurrentPlan` in `core/api/account/account.model.js` called `stripeService.getSubscription(account.stripe_subscription_id)` without checking the id. Internal and tester accounts have no Stripe subscription on purpose, so for them the Stripe SDK throws before any request and the dashboard request becomes a 500.

## Fix

- If `stripe_subscription_id` is null, skip Stripe and return `{ plan: 'unknown', product: 'unknown' }` (the values the apidoc already documents).
- Log at info level (expected case, not an anomaly).

## Test

- New test in `test/core/api/account/account.controller.test.js`: account with `stripe_subscription_id = null` gets a 200 with the unknown plan. Verified it fails with the Stripe error before the fix and passes after.
- `npm run prettier-check`, `npm run eslint`, and the account controller test suite pass locally (21 passing).

Fixes GLADYS-GATEWAY-DD

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JKg8X8ekCaefeFBtwz98zp