### PR TITLE
Remove BCC on all emails, keep visibility through Telegram metadata

### DIFF
--- a/core/index.js
+++ b/core/index.js
@@ -159,15 +159,16 @@ module.exports = async (port) => {
 
   const services = {
     fingerprint: Fingerprint(logger),
-    mailService: Mail(logger),
+    telegramService: Telegram(logger),
     jwtService: Jwt(),
     stripeService: Stripe(logger),
     slackService: Slack(logger),
-    telegramService: Telegram(logger),
     analyticsService: AnalyticsService(logger),
     openPanelService: OpenPanelService(logger),
     emailListService: EmailList(logger),
   };
+  // The mail service reports the metadata of the emails it sends on Telegram
+  services.mailService = Mail(logger, services.telegramService);
 
   const instanceModel = Instance(logger, db, redisClient, services.jwtService, services.fingerprint);
 

--- a/core/service/mail.js
+++ b/core/service/mail.js
@@ -3,7 +3,7 @@ const nodemailer = require('nodemailer');
 const emails = require('../common/email');
 const { normalizeLanguage } = require('../common/language');
 
-module.exports = function MailService(logger) {
+module.exports = function MailService(logger, telegramService) {
   let transporter;
 
   if (process.env.DISABLE_EMAIL !== 'true') {
@@ -40,7 +40,6 @@ module.exports = function MailService(logger) {
     const mailOptions = {
       from: process.env.EMAIL_FROM,
       to: user.email,
-      bcc: 'hello@gladysassistant.com',
       subject: emails[template][user.language].subject,
       html,
     };
@@ -57,6 +56,9 @@ module.exports = function MailService(logger) {
     }
 
     logger.info(`Sending ${template} email.`);
+    // Only notify metadata on Telegram: never forward the email body or the scope,
+    // as it may contain sensitive links (password reset, invitation token, email confirmation...)
+    telegramService.sendAlert(`Sending "${template}" email to ${user.email} (language = ${user.language})`);
     return transporter.sendMail(mailOptions);
   }
 

--- a/test/core/service/mail.test.js
+++ b/test/core/service/mail.test.js
@@ -1,12 +1,100 @@
-const logger = require('tracer').colorConsole();
+const { expect } = require('chai');
+const tracer = require('tracer');
+const nodemailer = require('nodemailer');
 const Mail = require('../../../core/service/mail');
 
-describe.skip('mail', function send() {
-  this.timeout(10000);
-  it('should send email', () => {
-    const mail = Mail(logger);
-    return mail.send({ email: 'hello@gladysassistant.com', language: 'en' }, 'confirmation', {
-      confirmationUrl: 'https://gladysassistant.com',
+const silentLogger = tracer.colorConsole({ level: 'error' });
+
+describe('mail service', () => {
+  let originalDisableEmail;
+  let originalCreateTransport;
+  let sentMails;
+  let telegramMessages;
+  let telegramService;
+
+  beforeEach(() => {
+    originalDisableEmail = process.env.DISABLE_EMAIL;
+    originalCreateTransport = nodemailer.createTransport;
+    sentMails = [];
+    telegramMessages = [];
+    telegramService = {
+      sendAlert: (text) => {
+        telegramMessages.push(text);
+      },
+    };
+    // Fake SMTP transporter so no real email is sent during tests
+    nodemailer.createTransport = () => ({
+      verify: (cb) => cb(null),
+      sendMail: async (mailOptions) => {
+        sentMails.push(mailOptions);
+        return { accepted: [mailOptions.to] };
+      },
     });
+  });
+
+  afterEach(() => {
+    nodemailer.createTransport = originalCreateTransport;
+    if (originalDisableEmail === undefined) {
+      delete process.env.DISABLE_EMAIL;
+    } else {
+      process.env.DISABLE_EMAIL = originalDisableEmail;
+    }
+  });
+
+  it('should send email to the user only, without any bcc', async () => {
+    process.env.DISABLE_EMAIL = 'false';
+    const mail = Mail(silentLogger, telegramService);
+
+    await mail.send({ email: 'user@example.com', language: 'en' }, 'confirmation', {
+      confirmationUrlGladys4: 'https://gladysassistant.com/confirm-email/super-secret-token',
+    });
+
+    expect(sentMails).to.have.lengthOf(1);
+    expect(sentMails[0].to).to.equal('user@example.com');
+    expect(sentMails[0]).to.not.have.property('bcc');
+    expect(sentMails[0]).to.not.have.property('cc');
+  });
+
+  it('should notify Telegram with metadata only, never the email content', async () => {
+    process.env.DISABLE_EMAIL = 'false';
+    const mail = Mail(silentLogger, telegramService);
+    const confirmationUrlGladys4 = 'https://gladysassistant.com/confirm-email/super-secret-token';
+
+    await mail.send({ email: 'user@example.com', language: 'en' }, 'confirmation', { confirmationUrlGladys4 });
+
+    expect(telegramMessages).to.have.lengthOf(1);
+    expect(telegramMessages[0]).to.include('confirmation');
+    expect(telegramMessages[0]).to.include('user@example.com');
+    expect(telegramMessages[0]).to.not.include('super-secret-token');
+    expect(telegramMessages[0]).to.not.include(confirmationUrlGladys4);
+  });
+
+  it('should not send email nor notify Telegram when email is disabled', async () => {
+    process.env.DISABLE_EMAIL = 'true';
+    const mail = Mail(silentLogger, telegramService);
+
+    await mail.send({ email: 'user@example.com', language: 'en' }, 'confirmation', {
+      confirmationUrlGladys4: 'https://gladysassistant.com',
+    });
+
+    expect(sentMails).to.have.lengthOf(0);
+    expect(telegramMessages).to.have.lengthOf(0);
+  });
+
+  it('should reject on invalid template without sending anything', async () => {
+    process.env.DISABLE_EMAIL = 'false';
+    const mail = Mail(silentLogger, telegramService);
+
+    let error;
+    try {
+      await mail.send({ email: 'user@example.com', language: 'en' }, 'unknown_template', {});
+    } catch (e) {
+      error = e;
+    }
+
+    expect(error).to.be.instanceOf(Error);
+    expect(error.message).to.equal('INVALID_TEMPLATE_OR_LANGUAGE');
+    expect(sentMails).to.have.lengthOf(0);
+    expect(telegramMessages).to.have.lengthOf(0);
   });
 });


### PR DESCRIPTION
## Why

Every email sent by the gateway was blind-copied to a shared mailbox. That included password reset links, invitation tokens and email confirmation links, so anyone with access to that mailbox held a way into any user account. For a product sold as end-to-end encrypted, those links should never leave the recipient's inbox.

The BCC existed to keep a pulse on what the gateway sends. That need is real, so it is kept, just without the sensitive payload.

## What changed

- `core/service/mail.js` no longer sets `bcc`. Emails go to the recipient only.
- The mail service now receives the Telegram service and, on each email actually sent, posts an alert with the template name, the recipient and the language. The email body and the EJS scope, which carry the tokens and links, are never forwarded.
- `core/index.js` instantiates the Telegram service before the mail service so it can be injected.

Telegram was already used across the gateway for operational alerts (new customer, payment failed, invitation accepted), so this reuses an existing channel rather than adding one. The alert still names the user's email address, consistent with the existing alerts. If you would rather keep zero personal data on Telegram, dropping the address and keeping only the template and language is a one-line change.

## Tests

The existing mail test was `describe.skip` and sent a real email through the configured SMTP server. It is replaced by unit tests that swap in a fake transporter, covering:

- the sent message has no `bcc` and no `cc`, and goes to the recipient
- the Telegram alert contains the template and recipient but never the token or the confirmation URL
- nothing is sent and nothing is reported when `DISABLE_EMAIL` is set
- an invalid template rejects without sending or alerting

I was not able to run ESLint, Prettier or Mocha in this session, so CI is the first real execution of these tests.

## Follow-up outside this diff

Emails sent before this ships are still sitting in the shared mailbox. Purging the old password reset and invitation messages, and confirming that mailbox has a strong password and 2FA, is worth doing alongside the merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012usVgV2tK2tjfJRuMv1XB3

---
_Generated by [Claude Code](https://claude.ai/code/session_012usVgV2tK2tjfJRuMv1XB3)_