### PR TITLE
Store the trial status of the subscription at checkout

### DIFF
--- a/core/api/account/account.model.js
+++ b/core/api/account/account.model.js
@@ -23,6 +23,14 @@ const ONE_DAY_IN_SECONDS = 24 * 60 * 60;
 const MAX_TRIAL_DAYS_FOR_EMAIL_LIST = 32;
 const GLADYS_PLUS_TRIAL_LIST = 'gladysPlusTrial';
 
+// Status stored on the account when a checkout session is completed. Stripe then holds the
+// subscription either active or trialing, and the status in database must reflect it (see
+// syncWithStripe in the admin API, which compares both). Anything else keeps the historical
+// default: the webhooks correct it afterwards.
+function getCheckoutAccountStatus(subscription) {
+  return subscription.status === 'trialing' ? 'trialing' : 'active';
+}
+
 module.exports = function AccountModel(
   logger,
   db,
@@ -221,7 +229,7 @@ module.exports = function AccountModel(
           stripe_customer_id: customer.id,
           stripe_subscription_id: subscription.id,
           current_period_end: new Date(subscription.current_period_end * 1000),
-          status: 'active',
+          status: getCheckoutAccountStatus(subscription),
           plan,
         },
         {
@@ -254,7 +262,7 @@ module.exports = function AccountModel(
       stripe_customer_id: customer.id,
       stripe_subscription_id: subscription.id,
       current_period_end: new Date(subscription.current_period_end * 1000),
-      status: 'active',
+      status: getCheckoutAccountStatus(subscription),
       plan,
     };
 
@@ -724,9 +732,9 @@ module.exports = function AccountModel(
 
         // Fetched as soon as this could be a yearly renewal: the subscription
         // carries both the interval, when the invoice does not, and the trial
-        // state, which `account.status` cannot be trusted for (a checkout
-        // account is inserted as `active` even while Stripe still has it
-        // trialing).
+        // state, which `account.status` cannot be trusted for (accounts created
+        // before the checkout stored the trial status are `active` in database
+        // even while Stripe still has them trialing).
         if ((!interval || interval === 'year') && subscriptionId) {
           subscription = await stripeService.getSubscription(subscriptionId);
           interval = interval || subscription?.items?.data?.[0]?.price?.recurring?.interval || null;

--- a/test/core/api/account/account.stripeWebhook.controller.test.js
+++ b/test/core/api/account/account.stripeWebhook.controller.test.js
@@ -308,6 +308,92 @@ describe('stripeWebhook', () => {
     expect(allAccounts[0]).to.have.property('stripe_subscription_id', 'sub_resub');
     expect(allAccounts[0]).to.have.property('status', 'active');
   });
+  it('should create new account as trialing when the Stripe subscription is in trial', async () => {
+    const event = {
+      id: 'evt_test_webhook',
+      object: 'event',
+      type: 'checkout.session.completed',
+      data: {
+        object: {
+          customer: 'cus_trial',
+          subscription: 'sub_trial',
+        },
+      },
+    };
+    const stringEvent = JSON.stringify(event);
+    const signatureHeader = stripe.webhooks.generateTestHeaderString({
+      payload: stringEvent,
+      secret: process.env.STRIPE_ENDPOINT_SECRET,
+    });
+    nock('https://api.stripe.com:443', { encodedQueryParams: true })
+      .get('/v1/subscriptions/sub_trial')
+      .reply(200, {
+        id: 'sub_trial',
+        status: 'trialing',
+        current_period_end: 1289482682000,
+        items: { data: [{ price: { product: 'plus-plan-id' } }] },
+      });
+    nock('https://api.stripe.com:443', { encodedQueryParams: true })
+      .get('/v1/customers/cus_trial')
+      .reply(200, { id: 'cus_trial', email: 'trial@test.fr' });
+
+    await request(TEST_BACKEND_APP)
+      .post('/stripe/webhook')
+      .set('Accept', 'application/json')
+      .set('stripe-signature', signatureHeader)
+      .set('Content-type', 'application/json')
+      .send(stringEvent)
+      .expect(200);
+
+    const account = await TEST_DATABASE_INSTANCE.t_account.findOne({ stripe_customer_id: 'cus_trial' });
+    expect(account).to.have.property('status', 'trialing');
+    expect(account).to.have.property('plan', 'plus');
+  });
+  it('should re-link an existing canceled account as trialing when the new subscription is in trial', async () => {
+    await TEST_DATABASE_INSTANCE.t_account.update('be2b9666-5c72-451e-98f4-efca76ffef54', { status: 'canceled' });
+
+    const event = {
+      id: 'evt_test_webhook',
+      object: 'event',
+      type: 'checkout.session.completed',
+      data: {
+        object: {
+          customer: 'cus_resub_trial',
+          subscription: 'sub_resub_trial',
+        },
+      },
+    };
+    const stringEvent = JSON.stringify(event);
+    const signatureHeader = stripe.webhooks.generateTestHeaderString({
+      payload: stringEvent,
+      secret: process.env.STRIPE_ENDPOINT_SECRET,
+    });
+    nock('https://api.stripe.com:443', { encodedQueryParams: true })
+      .get('/v1/subscriptions/sub_resub_trial')
+      .reply(200, {
+        id: 'sub_resub_trial',
+        status: 'trialing',
+        current_period_end: 1289482682000,
+        items: { data: [{ price: { product: 'plus-plan-id' } }] },
+      });
+    nock('https://api.stripe.com:443', { encodedQueryParams: true })
+      .get('/v1/customers/cus_resub_trial')
+      .reply(200, { id: 'cus_resub_trial', email: 'new-account-lost@gladysassistant.com' });
+
+    await request(TEST_BACKEND_APP)
+      .post('/stripe/webhook')
+      .set('Accept', 'application/json')
+      .set('stripe-signature', signatureHeader)
+      .set('Content-type', 'application/json')
+      .send(stringEvent)
+      .expect(200);
+
+    const allAccounts = await TEST_DATABASE_INSTANCE.t_account.find({ name: 'new-account-lost@gladysassistant.com' });
+    expect(allAccounts).to.have.lengthOf(1);
+    expect(allAccounts[0]).to.have.property('id', 'be2b9666-5c72-451e-98f4-efca76ffef54');
+    expect(allAccounts[0]).to.have.property('stripe_subscription_id', 'sub_resub_trial');
+    expect(allAccounts[0]).to.have.property('status', 'trialing');
+  });
   it('should create new account with lite plan', async () => {
     const event = {
       id: 'evt_test_webhook',


### PR DESCRIPTION
## Problem

An account created (or re-linked, on a re-subscription) from a completed checkout session was always inserted with `status: 'active'`, even when Stripe holds the subscription in `trialing`. Nothing corrected it afterwards: the `trialing -> active` webhook at the end of the trial writes `active` over `active`.

As a result, the Stripe reconciliation of the admin API (`sync-stripe`) reported every account in trial as differing from Stripe (`active` in database, `trialing` on Stripe).

## Change

- `createAccountFromStripeSession` now stores the status from the Stripe subscription at checkout: `trialing` when Stripe says so, `active` otherwise (unchanged historical default). Applied to both the new account and the re-linked account paths.
- Updated the comment in the `invoice.upcoming` handler, which described the old behaviour.
- Two tests: a new account and a re-linked account are stored as `trialing` when the subscription is in trial.

Both statuses grant access to Gladys Plus (`checkUserPlan`), so nothing changes for the customers. The only visible effect is on the public "paying users" stat, which counts `active` accounts only: accounts in trial will no longer be counted, which is the intended meaning of that stat.

Existing accounts already in trial with `active` in database are repaired by running `sync-stripe` with `execute: true`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014uWwncKrue3EULDMFzZGBf

---
_Generated by [Claude Code](https://claude.ai/code/session_014uWwncKrue3EULDMFzZGBf)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Accounts created or re-linked from trial subscriptions now correctly display a trialing status instead of active.
  * Trial subscription details, plans, and account associations are now handled correctly during checkout and webhook processing.

* **Tests**
  * Added coverage for new trial accounts and re-linking canceled accounts to trial subscriptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->