### PR TITLE
Refresh devDependencies: drop should, Prettier 3, chai 6, supertest 7

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -17,7 +17,6 @@
     "TEST_LEGACY_REDIS_CLIENT": true,
     "TEST_IO": true,
     "TEST_IO_SERVER_2": true,
-    "should": true,
     "beforeEach": true,
     "afterEach": true,
     "before": true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -50,20 +50,18 @@
         "tracer": "^1.3.0"
       },
       "devDependencies": {
-        "chai": "^4.2.0",
-        "chai-as-promised": "^7.1.1",
+        "chai": "^6.2.2",
+        "chai-as-promised": "^8.0.2",
         "eslint": "^8.29.0",
         "eslint-config-airbnb-base": "^15.0.0",
         "eslint-plugin-import": "^2.26.0",
         "mocha": "^12.0.0",
-        "nock": "^13.2.9",
+        "nock": "^13.5.6",
         "nodemon": "^3.1.14",
         "nyc": "^18.0.0",
-        "pify": "^5.0.0",
-        "prettier": "^2.3.2",
-        "should": "^13.2.3",
+        "prettier": "^3.9.6",
         "socket.io-client": "^4.8.0",
-        "supertest": "^3.3.0"
+        "supertest": "^7.2.2"
       },
       "engines": {
         "node": ">=24"
@@ -1670,6 +1668,19 @@
         "win32"
       ]
     },
+    "node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -1825,6 +1836,16 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@paralleldrive/cuid2": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@paralleldrive/cuid2/-/cuid2-2.3.1.tgz",
+      "integrity": "sha512-XO7cAxhnTZl0Yggq6jOgjiOHhbgcO4NqFqwSmQpjK3b6TEE6Uj/jfSk6wzYyemh3+I0sHirKSetjQwn5cZktFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "^1.1.5"
       }
     },
     "node_modules/@redis/bloom": {
@@ -3077,6 +3098,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/asap": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+      "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/asn1": {
       "version": "0.2.6",
       "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.6.tgz",
@@ -3084,16 +3112,6 @@
       "license": "MIT",
       "dependencies": {
         "safer-buffer": "~2.1.0"
-      }
-    },
-    "node_modules/assertion-error": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
-      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/async": {
@@ -3521,35 +3539,26 @@
       "license": "CC-BY-4.0"
     },
     "node_modules/chai": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/chai/-/chai-4.5.0.tgz",
-      "integrity": "sha512-RITGBfijLkBddZvnn8jdqoTypxvqbOLYQkGGxXzeFjVHvudaPw0HNFD9x928/eUwYWd2dPCugVqspGALTZZQKw==",
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "assertion-error": "^1.1.0",
-        "check-error": "^1.0.3",
-        "deep-eql": "^4.1.3",
-        "get-func-name": "^2.0.2",
-        "loupe": "^2.3.6",
-        "pathval": "^1.1.1",
-        "type-detect": "^4.1.0"
-      },
       "engines": {
-        "node": ">=4"
+        "node": ">=18"
       }
     },
     "node_modules/chai-as-promised": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/chai-as-promised/-/chai-as-promised-7.1.2.tgz",
-      "integrity": "sha512-aBDHZxRzYnUYuIAIPBH2s511DjlKPzXNlXSGFC8CwmroWQLfrW0LtE1nK3MAwwNhJPa9raEjNCmRoFpG0Hurdw==",
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/chai-as-promised/-/chai-as-promised-8.0.2.tgz",
+      "integrity": "sha512-1GadL+sEJVLzDjcawPM4kjfnL+p/9vrxiEUonowKOAzvVg0PixJUdtuDzdkDeQhK3zfOE76GqGkZIQ7/Adcrqw==",
       "dev": true,
-      "license": "WTFPL",
+      "license": "MIT",
       "dependencies": {
-        "check-error": "^1.0.2"
+        "check-error": "^2.1.1"
       },
       "peerDependencies": {
-        "chai": ">= 2.1.2 < 6"
+        "chai": ">= 2.1.2 < 7"
       }
     },
     "node_modules/chalk": {
@@ -3569,16 +3578,13 @@
       }
     },
     "node_modules/check-error": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.3.tgz",
-      "integrity": "sha512-iKEoDYaRmd1mxM90a2OEfWhjsjPpYPuQ+lMYsoxB126+t8fw7ySEO48nmDg5COTjxDI65/Y2OWpeEHk3ZOe8zg==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "get-func-name": "^2.0.2"
-      },
       "engines": {
-        "node": "*"
+        "node": ">= 16"
       }
     },
     "node_modules/chokidar": {
@@ -3780,13 +3786,6 @@
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.4.tgz",
       "integrity": "sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/core-util-is": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
-      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -4043,19 +4042,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/deep-eql": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-4.1.4.tgz",
-      "integrity": "sha512-SUwdGfqdKOwxCPeVYjwSyRpJ7Z+fhpwIAtmCUdZIWZ/YP5R9WAsyuSgpLVDi9bjWoN2LXHNss/dk3urXtdQxGg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "type-detect": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/deep-extend": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
@@ -4169,6 +4155,17 @@
       "optional": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/dezalgo": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.4.tgz",
+      "integrity": "sha512-rXSP0bf+5n0Qonsb+SVVfNfIsimO4HEtmnIpPHY8Q1UCzKlQrDMfdobr8nJOOsRgWCyMRqeSBQzmWUMq7zvVig==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "asap": "^2.0.0",
+        "wrappy": "1"
       }
     },
     "node_modules/diff": {
@@ -5020,6 +5017,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-safe-stringify": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
+      "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/fastq": {
       "version": "1.20.1",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
@@ -5269,12 +5273,19 @@
       }
     },
     "node_modules/formidable": {
-      "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.2.6.tgz",
-      "integrity": "sha512-KcpbcpuLNOwrEjnbpMC0gS+X8ciDoZE1kkqzat4a8vrprf+s9pKNQ/QIwWfbfs4ltgmFl3MD177SNTkve3BwGQ==",
-      "deprecated": "Please upgrade to latest, formidable@v2 or formidable@v3! Check these notes: https://bit.ly/2ZEqIau",
+      "version": "3.5.4",
+      "resolved": "https://registry.npmjs.org/formidable/-/formidable-3.5.4.tgz",
+      "integrity": "sha512-YikH+7CUTOtP44ZTnUhR7Ic2UASBPOqmaRkRKxRbywPTe5VxF7RRCck4af9wutiZ/QKM5nME9Bie2fFaPz5Gug==",
       "dev": true,
       "license": "MIT",
+      "dependencies": {
+        "@paralleldrive/cuid2": "^2.2.2",
+        "dezalgo": "^1.0.4",
+        "once": "^1.4.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
       "funding": {
         "url": "https://ko-fi.com/tunnckoCore/commissions"
       }
@@ -5496,16 +5507,6 @@
       "license": "ISC",
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
-      }
-    },
-    "node_modules/get-func-name": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.2.tgz",
-      "integrity": "sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/get-intrinsic": {
@@ -7134,16 +7135,6 @@
       "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
       "license": "MIT"
     },
-    "node_modules/loupe": {
-      "version": "2.3.7",
-      "resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.7.tgz",
-      "integrity": "sha512-zSMINGVYkdpYSOBmLi0D1Uo7JU9nVdQKrHxC8eYlV+9YKK9WePqAlL7lSlorG/U2Fw1w0hTBmaa/jrQ3UbPHtA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "get-func-name": "^2.0.1"
-      }
-    },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -8405,16 +8396,6 @@
       "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
       "license": "MIT"
     },
-    "node_modules/pathval": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz",
-      "integrity": "sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/pend": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
@@ -8550,19 +8531,6 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
-    "node_modules/pify": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/pify/-/pify-5.0.0.tgz",
-      "integrity": "sha512-eW/gHNMlxdSP6dmG6uJip6FXN0EQBwm2clYYd8Wul42Cwu/DK8HEftzsapcNdYe2MfLiIwZqsDk2RDEsTE79hA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/pkg-dir": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
@@ -8692,27 +8660,20 @@
       }
     },
     "node_modules/prettier": {
-      "version": "2.8.8",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
-      "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
+      "version": "3.9.6",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.6.tgz",
+      "integrity": "sha512-OpN0zzVdiaiAhxpuuj5efpIS4sY9j7bY6uR5mnj5yPzGkdkjNKSJeUThPb60Jw29QuAZgA4o+/iB49kFiaBX6g==",
       "dev": true,
       "license": "MIT",
       "bin": {
-        "prettier": "bin-prettier.js"
+        "prettier": "bin/prettier.cjs"
       },
       "engines": {
-        "node": ">=10.13.0"
+        "node": ">=14"
       },
       "funding": {
         "url": "https://github.com/prettier/prettier?sponsor=1"
       }
-    },
-    "node_modules/process-nextick-args": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/process-on-spawn": {
       "version": "1.1.0",
@@ -9452,66 +9413,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/should": {
-      "version": "13.2.3",
-      "resolved": "https://registry.npmjs.org/should/-/should-13.2.3.tgz",
-      "integrity": "sha512-ggLesLtu2xp+ZxI+ysJTmNjh2U0TsC+rQ/pfED9bUZZ4DKefP27D+7YJVVTvKsmjLpIi9jAa7itwDGkDDmt1GQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "should-equal": "^2.0.0",
-        "should-format": "^3.0.3",
-        "should-type": "^1.4.0",
-        "should-type-adaptors": "^1.0.1",
-        "should-util": "^1.0.0"
-      }
-    },
-    "node_modules/should-equal": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/should-equal/-/should-equal-2.0.0.tgz",
-      "integrity": "sha512-ZP36TMrK9euEuWQYBig9W55WPC7uo37qzAEmbjHz4gfyuXrEUgF8cUvQVO+w+d3OMfPvSRQJ22lSm8MQJ43LTA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "should-type": "^1.4.0"
-      }
-    },
-    "node_modules/should-format": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/should-format/-/should-format-3.0.3.tgz",
-      "integrity": "sha512-hZ58adtulAk0gKtua7QxevgUaXTTXxIi8t41L3zo9AHvjXO1/7sdLECuHeIN2SRtYXpNkmhoUP2pdeWgricQ+Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "should-type": "^1.3.0",
-        "should-type-adaptors": "^1.0.1"
-      }
-    },
-    "node_modules/should-type": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/should-type/-/should-type-1.4.0.tgz",
-      "integrity": "sha512-MdAsTu3n25yDbIe1NeN69G4n6mUnJGtSJHygX3+oN0ZbO3DTiATnf7XnYJdGT42JCXurTb1JI0qOBR65shvhPQ==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/should-type-adaptors": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/should-type-adaptors/-/should-type-adaptors-1.1.0.tgz",
-      "integrity": "sha512-JA4hdoLnN+kebEp2Vs8eBe9g7uy0zbRo+RMcU0EsNy+R+k049Ki+N5tT5Jagst2g7EAja+euFuoXFCa8vIklfA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "should-type": "^1.3.0",
-        "should-util": "^1.0.0"
-      }
-    },
-    "node_modules/should-util": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/should-util/-/should-util-1.0.1.tgz",
-      "integrity": "sha512-oXF8tfxx5cDk8r2kYqlkUJzZpDBqVY/II2WhvU0n9Y3XYvAYRmeaf1PvvIvTgPnv4KJ+ES5M0PyDq5Jp+Ygy2g==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/side-channel": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
@@ -10010,116 +9911,62 @@
       }
     },
     "node_modules/superagent": {
-      "version": "3.8.3",
-      "resolved": "https://registry.npmjs.org/superagent/-/superagent-3.8.3.tgz",
-      "integrity": "sha512-GLQtLMCoEIK4eDv6OGtkOoSMt3D+oq0y3dsxMuYuDvaNUvuT8eFBuLmfR0iYYzHC1e8hpzC6ZsxbuP6DIalMFA==",
-      "deprecated": "Please upgrade to superagent v10.2.2+, see release notes at https://github.com/forwardemail/superagent/releases/tag/v10.2.2 - maintenance is supported by Forward Email @ https://forwardemail.net",
+      "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/superagent/-/superagent-10.3.0.tgz",
+      "integrity": "sha512-B+4Ik7ROgVKrQsXTV0Jwp2u+PXYLSlqtDAhYnkkD+zn3yg8s/zjA2MeGayPoY/KICrbitwneDHrjSotxKL+0XQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "component-emitter": "^1.2.0",
-        "cookiejar": "^2.1.0",
-        "debug": "^3.1.0",
-        "extend": "^3.0.0",
-        "form-data": "^2.3.1",
-        "formidable": "^1.2.0",
-        "methods": "^1.1.1",
-        "mime": "^1.4.1",
-        "qs": "^6.5.1",
-        "readable-stream": "^2.3.5"
+        "component-emitter": "^1.3.1",
+        "cookiejar": "^2.1.4",
+        "debug": "^4.3.7",
+        "fast-safe-stringify": "^2.1.1",
+        "form-data": "^4.0.5",
+        "formidable": "^3.5.4",
+        "methods": "^1.1.2",
+        "mime": "2.6.0",
+        "qs": "^6.14.1"
       },
       "engines": {
-        "node": ">= 4.0"
+        "node": ">=14.18.0"
       }
     },
-    "node_modules/superagent/node_modules/debug": {
-      "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
-      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+    "node_modules/superagent/node_modules/mime": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
+      "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.1"
-      }
-    },
-    "node_modules/superagent/node_modules/form-data": {
-      "version": "2.5.6",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.6.tgz",
-      "integrity": "sha512-Ogz/E85h9tlfJzpI6TuFpGcHZFhLrb9Gw8wq9v40CxSCPnv7ahKr6Xgtkn0KYCDQJ8DNn5VoMO8EXr9V5PadyA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.4",
-        "mime-types": "^2.1.35",
-        "safe-buffer": "^5.2.1"
+      "bin": {
+        "mime": "cli.js"
       },
       "engines": {
-        "node": ">= 0.12"
+        "node": ">=4.0.0"
       }
-    },
-    "node_modules/superagent/node_modules/isarray": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/superagent/node_modules/readable-stream": {
-      "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
-      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.1.1",
-        "util-deprecate": "~1.0.1"
-      }
-    },
-    "node_modules/superagent/node_modules/readable-stream/node_modules/safe-buffer": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/superagent/node_modules/string_decoder": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "~5.1.0"
-      }
-    },
-    "node_modules/superagent/node_modules/string_decoder/node_modules/safe-buffer": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/supertest": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/supertest/-/supertest-3.4.2.tgz",
-      "integrity": "sha512-WZWbwceHUo2P36RoEIdXvmqfs47idNNZjCuJOqDz6rvtkk8ym56aU5oglORCpPeXGxT7l9rkJ41+O1lffQXYSA==",
-      "deprecated": "Please upgrade to supertest v7.1.3+, see release notes at https://github.com/forwardemail/supertest/releases/tag/v7.1.3 - maintenance is supported by Forward Email @ https://forwardemail.net",
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/supertest/-/supertest-7.2.2.tgz",
+      "integrity": "sha512-oK8WG9diS3DlhdUkcFn4tkNIiIbBx9lI2ClF8K+b2/m8Eyv47LSawxUzZQSNKUrVb2KsqeTDCcjAAVPYaSLVTA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
+        "cookie-signature": "^1.2.2",
         "methods": "^1.1.2",
-        "superagent": "^3.8.3"
+        "superagent": "^10.3.0"
       },
       "engines": {
-        "node": ">=6.0.0"
+        "node": ">=14.18.0"
+      }
+    },
+    "node_modules/supertest/node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
       }
     },
     "node_modules/supports-color": {
@@ -10375,16 +10222,6 @@
       },
       "engines": {
         "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/type-detect": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.1.0.tgz",
-      "integrity": "sha512-Acylog8/luQ8L7il+geoSxhEkazvkslg7PSNKOX59mbB9cOveP5aq9h74Y7YU8yDpJwetzQQrfIwtf4Wp4LKcw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/type-fest": {

--- a/package.json
+++ b/package.json
@@ -45,20 +45,18 @@
   },
   "homepage": "https://github.com/gladysassistant/gladys-gateway#readme",
   "devDependencies": {
-    "chai": "^4.2.0",
-    "chai-as-promised": "^7.1.1",
+    "chai": "^6.2.2",
+    "chai-as-promised": "^8.0.2",
     "eslint": "^8.29.0",
     "eslint-config-airbnb-base": "^15.0.0",
     "eslint-plugin-import": "^2.26.0",
     "mocha": "^12.0.0",
-    "nock": "^13.2.9",
+    "nock": "^13.5.6",
     "nodemon": "^3.1.14",
     "nyc": "^18.0.0",
-    "pify": "^5.0.0",
-    "prettier": "^2.3.2",
-    "should": "^13.2.3",
+    "prettier": "^3.9.6",
     "socket.io-client": "^4.8.0",
-    "supertest": "^3.3.0"
+    "supertest": "^7.2.2"
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.332.0",

--- a/test/bootstrap.test.js
+++ b/test/bootstrap.test.js
@@ -1,10 +1,10 @@
 let databaseTask;
 let redisTask;
-const should = require('should'); // eslint-disable-line no-unused-vars
 require('./tasks/nock');
 const Dotenv = require('dotenv');
 const chai = require('chai');
-const chaiAsPromised = require('chai-as-promised');
+// chai-as-promised v8 is ESM-only: require() returns the module namespace, the plugin is its default export
+const { default: chaiAsPromised } = require('chai-as-promised');
 
 Dotenv.config();
 

--- a/test/core/api/account/account.controller.test.js
+++ b/test/core/api/account/account.controller.test.js
@@ -12,10 +12,10 @@ describe('GET /accounts/users', () => {
       .expect('Content-Type', /json/)
       .expect(200)
       .then((response) => {
-        response.body.should.be.instanceOf(Array);
+        expect(response.body).to.be.instanceOf(Array);
         response.body.forEach((user) => {
-          user.should.have.property('email');
-          user.should.have.property('is_invitation');
+          expect(user).to.have.property('email');
+          expect(user).to.have.property('is_invitation');
         });
       }));
 });
@@ -32,7 +32,7 @@ describe('POST /accounts/subscribe', () => {
       .expect('Content-Type', /json/)
       .expect(200)
       .then((response) => {
-        response.body.should.have.property('current_period_end');
+        expect(response.body).to.have.property('current_period_end');
       }));
 });
 
@@ -45,7 +45,7 @@ describe('POST /accounts/users/:id/revoke', () => {
       .expect('Content-Type', /json/)
       .expect(200)
       .then((response) => {
-        response.body.should.have.property('success', true);
+        expect(response.body).to.have.property('success', true);
       }));
 });
 
@@ -58,7 +58,7 @@ describe('GET /accounts/invoices', () => {
       .expect('Content-Type', /json/)
       .expect(200)
       .then((response) => {
-        should.deepEqual(response.body, [
+        expect(response.body).to.deep.equal([
           {
             id: '88b4b295-deae-4452-a5f0-e67f18cf6abe',
             hosted_invoice_url: 'test',

--- a/test/core/api/admin/admin.controller.test.js
+++ b/test/core/api/admin/admin.controller.test.js
@@ -15,7 +15,7 @@ describe('POST /admin/accounts/:id/resend', () => {
       .expect('Content-Type', /json/)
       .expect(200)
       .then((response) => {
-        response.body.should.have.property('status', 200);
+        expect(response.body).to.have.property('status', 200);
       });
   });
 });
@@ -92,8 +92,8 @@ describe('GET /admin/accounts', () => {
       .expect(200)
       .then((response) => {
         response.body.forEach((account) => {
-          account.should.have.property('id');
-          account.should.have.property('user_count');
+          expect(account).to.have.property('id');
+          expect(account).to.have.property('user_count');
         });
       });
   });

--- a/test/core/api/backup/utils.test.js
+++ b/test/core/api/backup/utils.test.js
@@ -1,18 +1,12 @@
-const { promisify } = require('util');
 const fs = require('fs');
 const { Buffer } = require('buffer');
-const pify = require('pify');
-
-const fsReadP = pify(fs.read, { multiArgs: true });
-const fsOpenP = promisify(fs.open);
-const fsCloseP = promisify(fs.close);
 
 async function readChunk(filePath, { length, startPosition }) {
-  const fileDescriptor = await fsOpenP(filePath, 'r');
+  const fileHandle = await fs.promises.open(filePath, 'r');
 
   try {
     // eslint-disable-next-line prefer-const
-    let [bytesRead, buffer] = await fsReadP(fileDescriptor, {
+    let { bytesRead, buffer } = await fileHandle.read({
       buffer: Buffer.alloc(length),
       length,
       position: startPosition,
@@ -24,7 +18,7 @@ async function readChunk(filePath, { length, startPosition }) {
 
     return buffer;
   } finally {
-    await fsCloseP(fileDescriptor);
+    await fileHandle.close();
   }
 }
 

--- a/test/core/api/device/device.controller.test.js
+++ b/test/core/api/device/device.controller.test.js
@@ -1,4 +1,5 @@
 const request = require('supertest');
+const { expect } = require('chai');
 const configTest = require('../../../tasks/config');
 
 describe('GET /users/me/devices', () => {
@@ -10,7 +11,7 @@ describe('GET /users/me/devices', () => {
       .expect('Content-Type', /json/)
       .expect(200)
       .then((response) => {
-        should.deepEqual(response.body, [
+        expect(response.body).to.deep.equal([
           {
             id: '1356c620-0c88-46fc-87bf-de620f30f0e3',
             name: 'Safari Tony Stark',
@@ -30,7 +31,7 @@ describe('POST /devices/:id/revoke', () => {
       .expect('Content-Type', /json/)
       .expect(200)
       .then((response) => {
-        should.deepEqual(response.body, {
+        expect(response.body).to.deep.equal({
           id: '1356c620-0c88-46fc-87bf-de620f30f0e3',
           revoked: true,
         });

--- a/test/core/api/instance/instance.controllers.test.js
+++ b/test/core/api/instance/instance.controllers.test.js
@@ -1,5 +1,5 @@
 const request = require('supertest');
-const should = require('should');
+const { expect } = require('chai');
 const configTest = require('../../../tasks/config');
 const Jwt = require('../../../../core/service/jwt');
 
@@ -12,7 +12,7 @@ describe('GET /instances', () => {
       .expect('Content-Type', /json/)
       .expect(200)
       .then((response) => {
-        should.deepEqual(response.body, [
+        expect(response.body).to.deep.equal([
           {
             id: '0bc53f3c-1e11-40d3-99a4-bd392a666eaf',
             name: 'Raspberry Pi 1',
@@ -33,7 +33,7 @@ describe('GET /instances/:id', () => {
       .expect('Content-Type', /json/)
       .expect(200)
       .then((response) => {
-        should.deepEqual(response.body, {
+        expect(response.body).to.deep.equal({
           id: '0bc53f3c-1e11-40d3-99a4-bd392a666eaf',
           name: 'Raspberry Pi 1',
           rsa_public_key: 'public-key',
@@ -61,9 +61,9 @@ describe('POST /instances', () => {
       .expect('Content-Type', /json/)
       .expect(201)
       .then((response) => {
-        response.body.should.have.property('access_token');
-        response.body.should.have.property('refresh_token');
-        response.body.should.have.property('id');
+        expect(response.body).to.have.property('access_token');
+        expect(response.body).to.have.property('refresh_token');
+        expect(response.body).to.have.property('id');
       }));
 
   it('should not create an instance with a read-only token', () =>
@@ -98,8 +98,8 @@ describe('POST /instances', () => {
     const instances = await TEST_DATABASE_INSTANCE.t_instance.find({
       account_id: 'b2d23f66-487d-493f-8acb-9c8adb400def',
     });
-    instances.should.have.length(1);
-    instances[0].should.have.property('primary_instance', true);
+    expect(instances).to.have.lengthOf(1);
+    expect(instances[0]).to.have.property('primary_instance', true);
   });
 });
 
@@ -112,7 +112,7 @@ describe('GET /instances/access-token', () => {
       .expect('Content-Type', /json/)
       .expect(200)
       .then((response) => {
-        response.body.should.have.property('access_token');
+        expect(response.body).to.have.property('access_token');
       }));
 });
 
@@ -126,10 +126,10 @@ describe('GET /instances/users', () => {
       .expect(200)
       .then((response) => {
         response.body.forEach((user) => {
-          user.should.have.property('id');
-          user.should.have.property('rsa_public_key');
-          user.should.have.property('ecdsa_public_key');
-          user.should.have.property('connected');
+          expect(user).to.have.property('id');
+          expect(user).to.have.property('rsa_public_key');
+          expect(user).to.have.property('ecdsa_public_key');
+          expect(user).to.have.property('connected');
         });
       }));
 });

--- a/test/core/api/invitation/invitation.controller.test.js
+++ b/test/core/api/invitation/invitation.controller.test.js
@@ -1,5 +1,5 @@
 const request = require('supertest');
-const should = require('should');
+const { expect } = require('chai');
 const crypto = require('crypto');
 const configTest = require('../../../tasks/config');
 
@@ -15,7 +15,7 @@ describe('POST /invitations', () => {
       })
       .expect('Content-Type', /json/)
       .expect(200);
-    should.deepEqual(response.body, {
+    expect(response.body).to.deep.equal({
       id: response.body.id,
       email: 'pepper.potts@starkindustries.com',
       role: 'user',
@@ -37,12 +37,12 @@ describe('POST /invitations', () => {
       .expect('Content-Type', /json/)
       .expect(200);
 
-    should.equal(response.body.email, 'pepper.potts.mixed@starkindustries.com');
+    expect(response.body.email).to.equal('pepper.potts.mixed@starkindustries.com');
 
     const invitation = await TEST_DATABASE_INSTANCE.t_invitation.findOne({
       id: response.body.id,
     });
-    should.equal(invitation.email, 'pepper.potts.mixed@starkindustries.com');
+    expect(invitation.email).to.equal('pepper.potts.mixed@starkindustries.com');
   });
 
   it('should not send invitation, wrong email', () =>
@@ -79,7 +79,7 @@ describe('POST /invitations/accept', () => {
       .expect('Content-Type', /json/)
       .expect(201)
       .then((response) => {
-        should.deepEqual(response.body, {
+        expect(response.body).to.deep.equal({
           status: 201,
           message: 'User created with success.',
         });
@@ -119,8 +119,8 @@ describe('POST /invitations/accept', () => {
     const user = await TEST_DATABASE_INSTANCE.t_user.findOne({
       email: 'mixed.case.user@example.com',
     });
-    should.exist(user);
-    should.equal(user.email, 'mixed.case.user@example.com');
+    expect(user).to.be.an('object');
+    expect(user.email).to.equal('mixed.case.user@example.com');
   });
 
   it('should not accept invitation, not found hash', () =>
@@ -175,7 +175,7 @@ describe('GET /invitations/:id', () => {
       .expect('Content-Type', /json/)
       .expect(200)
       .then((response) => {
-        should.deepEqual(response.body, {
+        expect(response.body).to.deep.equal({
           email: 'oneuserinvited@gladysassistant.com',
           id: 'b141f826-5e43-4aa6-807e-a37d4e9177de',
         });
@@ -191,7 +191,7 @@ describe('POST /invitations/:id/revoke', () => {
       .expect('Content-Type', /json/)
       .expect(200)
       .then((response) => {
-        should.deepEqual(response.body, {
+        expect(response.body).to.deep.equal({
           success: true,
         });
       }));

--- a/test/core/api/openapi/openapi.api.controller.test.js
+++ b/test/core/api/openapi/openapi.api.controller.test.js
@@ -1,4 +1,5 @@
 const request = require('supertest');
+const { expect } = require('chai');
 const configTest = require('../../../tasks/config');
 
 describe('POST /v1/api/event/:open-api-key', () => {
@@ -85,7 +86,7 @@ describe('POST /v1/api/external-integration/:open-api-key/:selector/:webhook-key
       .send({ test: true })
       .expect(200)
       .then((response) => {
-        response.text.should.equal('');
+        expect(response.text).to.equal('');
       }));
 
   it('should return 200 empty when account has no primary instance', async () => {
@@ -101,7 +102,7 @@ describe('POST /v1/api/external-integration/:open-api-key/:selector/:webhook-key
       .send({ test: true })
       .expect(200)
       .then((response) => {
-        response.text.should.equal('');
+        expect(response.text).to.equal('');
       });
   });
 });
@@ -122,7 +123,7 @@ describe('GET /v1/api/external-integration/:open-api-key/:selector/:webhook-key'
       .set('Accept', 'application/json')
       .expect(200)
       .then((response) => {
-        response.text.should.equal('');
+        expect(response.text).to.equal('');
       }));
 });
 

--- a/test/core/api/openapi/openapi.controller.test.js
+++ b/test/core/api/openapi/openapi.controller.test.js
@@ -1,5 +1,5 @@
 const request = require('supertest');
-const should = require('should');
+const { expect } = require('chai');
 const configTest = require('../../../tasks/config');
 const Jwt = require('../../../../core/service/jwt');
 
@@ -20,8 +20,8 @@ describe('POST /open-api-keys', () => {
       .expect('Content-Type', /json/)
       .expect(200)
       .then((response) => {
-        response.body.should.have.property('api_key');
-        response.body.should.have.property('name', 'My new api key');
+        expect(response.body).to.have.property('api_key');
+        expect(response.body).to.have.property('name', 'My new api key');
       }));
 
   it('should not create a new open api key (missing name)', () =>
@@ -42,7 +42,7 @@ describe('GET /open-api-keys', () => {
       .expect('Content-Type', /json/)
       .expect(200)
       .then((response) => {
-        should.deepEqual(response.body, [
+        expect(response.body).to.deep.equal([
           {
             id: '4a01dfc5-899e-4a95-9288-c6096f1be180',
             name: 'Open API Key',
@@ -70,7 +70,7 @@ describe('DELETE /open-api-keys/:id', () => {
       .expect('Content-Type', /json/)
       .expect(404);
     const key = await TEST_DATABASE_INSTANCE.t_open_api_key.findOne({ id: '4a01dfc5-899e-4a95-9288-c6096f1be180' });
-    key.should.have.property('revoked', false);
+    expect(key).to.have.property('revoked', false);
   });
 });
 
@@ -86,7 +86,7 @@ describe('PATCH /open-api-keys/:id', () => {
       .expect('Content-Type', /json/)
       .expect(200)
       .then((response) => {
-        response.body.should.have.property('name', 'new-name');
+        expect(response.body).to.have.property('name', 'new-name');
       }));
 
   it('should not update the name of the api key of another user', async () => {
@@ -100,7 +100,7 @@ describe('PATCH /open-api-keys/:id', () => {
       .expect('Content-Type', /json/)
       .expect(404);
     const key = await TEST_DATABASE_INSTANCE.t_open_api_key.findOne({ id: '4a01dfc5-899e-4a95-9288-c6096f1be180' });
-    key.should.have.property('name', 'Open API Key');
+    expect(key).to.have.property('name', 'Open API Key');
   });
 
   it('should return 422 when the name is missing', () =>

--- a/test/core/api/stat/stat.controller.test.js
+++ b/test/core/api/stat/stat.controller.test.js
@@ -1,4 +1,5 @@
 const request = require('supertest');
+const { expect } = require('chai');
 
 describe('GET /stats', () => {
   it('should return stats', () =>
@@ -8,12 +9,12 @@ describe('GET /stats', () => {
       .expect('Content-Type', /json/)
       .expect(200)
       .then((response) => {
-        response.body.should.have.property('gladys_4_instances');
-        response.body.should.have.property('nb_gladys_plus_users', 0);
-        response.body.gladys_4_instances.should.be.instanceOf(Array);
+        expect(response.body).to.have.property('gladys_4_instances');
+        expect(response.body).to.have.property('nb_gladys_plus_users', 0);
+        expect(response.body.gladys_4_instances).to.be.instanceOf(Array);
         response.body.gladys_4_instances.forEach((month) => {
-          month.should.have.property('nb_instances');
-          month.should.have.property('month');
+          expect(month).to.have.property('nb_instances');
+          expect(month).to.have.property('month');
         });
       }));
   it('should count an active account with a Stripe subscription as paying user', async () => {
@@ -22,7 +23,7 @@ describe('GET /stats', () => {
       { stripe_customer_id: 'cus_paying', stripe_subscription_id: 'sub_paying' },
     );
     const response = await request(TEST_BACKEND_APP).get('/stats').expect(200);
-    response.body.should.have.property('nb_gladys_plus_users', 1);
+    expect(response.body).to.have.property('nb_gladys_plus_users', 1);
   });
   it('should not count internal accounts as paying users', async () => {
     await TEST_DATABASE_INSTANCE.t_account.update(
@@ -30,7 +31,7 @@ describe('GET /stats', () => {
       { stripe_customer_id: 'cus_paying', stripe_subscription_id: 'sub_paying', is_internal: true },
     );
     const response = await request(TEST_BACKEND_APP).get('/stats').expect(200);
-    response.body.should.have.property('nb_gladys_plus_users', 0);
+    expect(response.body).to.have.property('nb_gladys_plus_users', 0);
   });
   it('should return stats a second time', () =>
     request(TEST_BACKEND_APP)
@@ -39,12 +40,12 @@ describe('GET /stats', () => {
       .expect('Content-Type', /json/)
       .expect(200)
       .then((response) => {
-        response.body.should.have.property('gladys_4_instances');
-        response.body.should.have.property('nb_gladys_plus_users', 0);
-        response.body.gladys_4_instances.should.be.instanceOf(Array);
+        expect(response.body).to.have.property('gladys_4_instances');
+        expect(response.body).to.have.property('nb_gladys_plus_users', 0);
+        expect(response.body.gladys_4_instances).to.be.instanceOf(Array);
         response.body.gladys_4_instances.forEach((month) => {
-          month.should.have.property('nb_instances');
-          month.should.have.property('month');
+          expect(month).to.have.property('nb_instances');
+          expect(month).to.have.property('month');
         });
       }));
 });

--- a/test/core/api/tts/tts.controller.test.js
+++ b/test/core/api/tts/tts.controller.test.js
@@ -49,9 +49,12 @@ describe('TTS API', () => {
       .set('Accept', 'application/json')
       .set('Authorization', configTest.jwtAccessTokenInstance)
       .send()
+      // superagent does not buffer audio/* bodies by default, ask for the raw bytes
+      .responseType('arraybuffer')
       .expect('Content-Type', 'audio/mpeg')
       .expect(200);
-    expect(responseMp3File.text).to.deep.equal(voiceFile.toString());
+    expect(Buffer.isBuffer(responseMp3File.body)).to.equal(true);
+    expect(responseMp3File.body.equals(voiceFile)).to.equal(true);
   });
   it('should return 401', async () => {
     const response = await request(TEST_BACKEND_APP)

--- a/test/core/api/user/user.controller.test.js
+++ b/test/core/api/user/user.controller.test.js
@@ -142,7 +142,7 @@ describe('POST /users/login-salt', () => {
       .expect('Content-Type', /json/)
       .expect(200)
       .then((response) => {
-        should.deepEqual(response.body, {
+        expect(response.body).to.deep.equal({
           srp_salt: 'e0812f8c57be08780bafcc7e2cbacd155b6f63962114c12cc12462a7aa669fdb',
         });
       }));
@@ -156,7 +156,7 @@ describe('POST /users/login-salt', () => {
       .expect('Content-Type', /json/)
       .expect(200)
       .then((response) => {
-        should.deepEqual(response.body, {
+        expect(response.body).to.deep.equal({
           srp_salt: 'e0812f8c57be08780bafcc7e2cbacd155b6f63962114c12cc12462a7aa669fdb',
         });
       }));
@@ -184,8 +184,8 @@ describe('POST /users/login-generate-ephemeral', () => {
       .expect('Content-Type', /json/)
       .expect(200)
       .then((response) => {
-        response.body.should.have.property('server_ephemeral_public');
-        response.body.should.have.property('login_session_key');
+        expect(response.body).to.have.property('server_ephemeral_public');
+        expect(response.body).to.have.property('login_session_key');
       }));
   it('should return 404 not found', () =>
     request(TEST_BACKEND_APP)
@@ -211,8 +211,8 @@ describe('POST /users/login-finalize', () => {
       .expect('Content-Type', /json/)
       .expect(200)
       .then((response) => {
-        response.body.should.have.property('server_session_proof');
-        response.body.should.have.property('access_token');
+        expect(response.body).to.have.property('server_session_proof');
+        expect(response.body).to.have.property('access_token');
       }));
 
   it('should return 403 forbidden. Wrong client proof', () =>
@@ -237,7 +237,7 @@ describe('POST /users/two-factor-configure', () => {
       .expect('Content-Type', /json/)
       .expect(200)
       .then((response) => {
-        response.body.should.have.property('otpauth_url');
+        expect(response.body).to.have.property('otpauth_url');
       }));
 
   it('should return 401 unauthorized, no jwt provided', () =>
@@ -267,7 +267,7 @@ describe('POST /users/two-factor-enable', () => {
       .expect('Content-Type', /json/)
       .expect(200)
       .then((response) => {
-        response.body.should.have.property('two_factor_enabled', true);
+        expect(response.body).to.have.property('two_factor_enabled', true);
       });
   });
 
@@ -661,7 +661,7 @@ describe('PATCH /users/me', () => {
       .expect('Content-Type', /json/)
       .expect(200)
       .then((response) => {
-        response.body.should.have.property('name', 'my new name');
+        expect(response.body).to.have.property('name', 'my new name');
       }));
 
   it('should update user email with the current two factor code and send email', async () => {
@@ -807,7 +807,7 @@ describe('GET /users/me', () => {
       .expect('Content-Type', /json/)
       .expect(200)
       .then((response) => {
-        should.deepEqual(response.body, {
+        expect(response.body).to.deep.equal({
           id: 'a139e4a6-ec6c-442d-9730-0499155d38d4',
           name: 'Tony',
           email: 'email-confirmed-two-factor-enabled@gladysprojet.com',
@@ -836,7 +836,7 @@ describe('POST /users/forgot-password', () => {
       .expect('Content-Type', /json/)
       .expect(200)
       .then((response) => {
-        should.deepEqual(response.body, {
+        expect(response.body).to.deep.equal({
           success: true,
         });
       }));
@@ -851,7 +851,7 @@ describe('POST /users/forgot-password', () => {
       .expect('Content-Type', /json/)
       .expect(200)
       .then((response) => {
-        should.deepEqual(response.body, {
+        expect(response.body).to.deep.equal({
           success: true,
         });
       }));
@@ -893,7 +893,7 @@ describe('POST /users/reset-password', () => {
       .expect('Content-Type', /json/)
       .expect(200)
       .then((response) => {
-        should.deepEqual(response.body, {
+        expect(response.body).to.deep.equal({
           success: true,
         });
       }));
@@ -916,7 +916,7 @@ describe('POST /users/reset-password', () => {
       .expect('Content-Type', /json/)
       .expect(200)
       .then((response) => {
-        should.deepEqual(response.body, {
+        expect(response.body).to.deep.equal({
           success: true,
         });
       }));
@@ -1047,7 +1047,7 @@ describe('GET /users/reset-password/:token', () => {
       .expect('Content-Type', /json/)
       .expect(200)
       .then((response) => {
-        should.deepEqual(response.body, {
+        expect(response.body).to.deep.equal({
           id: 'a139e4a6-ec6c-442d-9730-0499155d38d4',
           email: 'email-confirmed-two-factor-enabled@gladysprojet.com',
           two_factor_enabled: true,
@@ -1064,7 +1064,7 @@ describe('GET /users/setup', () => {
       .expect('Content-Type', /json/)
       .expect(200)
       .then((response) => {
-        should.deepEqual(response.body, {
+        expect(response.body).to.deep.equal({
           billing_setup: false,
           stripe_portal_key: 'fee71731-5928-4f2f-a74b-c7858d39372f',
           gladys_instance_setup: true,
@@ -1082,7 +1082,7 @@ describe('GET /users/two-factor/new', () => {
       .expect('Content-Type', /json/)
       .expect(200)
       .then((response) => {
-        response.body.should.have.property('otpauth_url');
+        expect(response.body).to.have.property('otpauth_url');
       }));
 });
 

--- a/test/core/api/version/version.controller.test.js
+++ b/test/core/api/version/version.controller.test.js
@@ -1,5 +1,5 @@
 const request = require('supertest');
-const should = require('should');
+const { expect } = require('chai');
 
 describe('GET/POST /v1/api/gladys/version', () => {
   it('should return status 200', () =>
@@ -9,7 +9,7 @@ describe('GET/POST /v1/api/gladys/version', () => {
       .expect('Content-Type', /json/)
       .expect(200)
       .then((res) => {
-        should.deepEqual(res.body, {
+        expect(res.body).to.deep.equal({
           name: 'v4.0.0-alpha',
           created_at: '2018-10-16T02:21:25.901Z',
           default_release_note_link: 'https://github.com/GladysAssistant/Gladys/releases/tag/v4.57.0',
@@ -32,7 +32,7 @@ describe('GET/POST /v1/api/gladys/version', () => {
       .expect('Content-Type', /json/)
       .expect(200)
       .then((res) => {
-        should.deepEqual(res.body, {
+        expect(res.body).to.deep.equal({
           name: 'v4.0.0-alpha',
           created_at: '2018-10-16T02:21:25.901Z',
           default_release_note_link: 'https://github.com/GladysAssistant/Gladys/releases/tag/v4.57.0',


### PR DESCRIPTION
## Summary

A pass over the `devDependencies`, as requested.

| Package | Before | After |
|---|---|---|
| `should` | ^13.2.3 | **removed** (replaced by chai `expect`) |
| `prettier` | ^2.3.2 | ^3.9.6 |
| `chai` | ^4.2.0 | ^6.2.2 |
| `chai-as-promised` | ^7.1.1 | ^8.0.2 |
| `supertest` | ^3.3.0 | ^7.2.2 |
| `pify` | ^5.0.0 | **removed** (replaced by `fs.promises`) |
| `nock` | ^13.2.9 | ^13.5.6 (see below) |

Already up to date and untouched: `eslint-config-airbnb-base`, `eslint-plugin-import`, `mocha`, `nodemon`, `nyc`, `socket.io-client`.

## Changes

- **`should` → chai.** Every `should` assertion in the tests (`x.should.have.property`, `should.deepEqual`, `should.equal`, `should.exist`, `should.be.instanceOf`, `should.have.length`) is rewritten with chai's `expect`, which most of the suite already used. The `should` global is removed from `.eslintrc.json`.
- **Prettier 3.** The repo already sets `trailingComma: all`, so the new v3 defaults produce zero formatting changes; `npm run prettier-check` is green.
- **chai 6 / chai-as-promised 8.** Both are ESM-only now. On Node ≥ 22.12 (the project requires 24) `require()` loads them natively, but the chai-as-promised plugin is the module's default export, so `test/bootstrap.test.js` now does `const { default: chaiAsPromised } = require('chai-as-promised')`.
- **supertest 7.** superagent no longer buffers `audio/*` bodies into `response.text`, so the TTS test now requests `responseType('arraybuffer')` and compares buffers.
- **pify removed.** The backup test helper uses `fs.promises.open()` file handles instead.

## Deliberately kept as is

- **nock stays on 13.x.** nock 14 switched to msw interceptors, and every Stripe call made by the stripe v8 SDK then hangs until the mocha timeout (87 failures): the SDK waits for a socket `connect` event that the new interceptor never emits. Moving to nock 14 needs a Stripe SDK upgrade first.
- **eslint stays on 8.x.** `eslint-config-airbnb-base@15` only declares eslint 7/8 as peers, and eslint 9+ requires the flat config migration. Worth its own PR.

## Test plan

- [x] `npm run prettier-check` green
- [x] `npm run eslint` green (only the pre-existing `no-console` warning)
- [x] `npm run coverage` locally with Postgres 16 + Redis: 493 passing, 23 failing, exactly the same 23 as on `master` before this change (backup/camera/google tests needing the AWS and Google secrets the CI injects)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0177YUhDENZmKopWbwYjgJ7S

---
_Generated by [Claude Code](https://claude.ai/code/session_0177YUhDENZmKopWbwYjgJ7S)_