### PR TITLE
Restore the test coverage lost with supertest 7

### DIFF
--- a/test/core/api/version/version.controller.test.js
+++ b/test/core/api/version/version.controller.test.js
@@ -5,6 +5,8 @@ describe('GET/POST /v1/api/gladys/version', () => {
   it('should return status 200', () =>
     request(TEST_BACKEND_APP)
       .get('/v1/api/gladys/version')
+      // supertest >= 4 no longer sends a default User-Agent, the usage middleware records it
+      .set('user-agent', 'Gladys/4.57.0')
       .set('Accept', 'application/json')
       .expect('Content-Type', /json/)
       .expect(200)
@@ -19,6 +21,8 @@ describe('GET/POST /v1/api/gladys/version', () => {
   it('should return status 200', () =>
     request(TEST_BACKEND_APP)
       .post('/v1/api/gladys/version')
+      // supertest >= 4 no longer sends a default User-Agent, the usage middleware records it
+      .set('user-agent', 'Gladys/4.57.0')
       .set('Accept', 'application/json')
       .send({
         is_docker: true,

--- a/test/core/enedis/enedis.getContract.test.js
+++ b/test/core/enedis/enedis.getContract.test.js
@@ -97,6 +97,11 @@ describe('EnedisWorker.getContract', function Describe() {
       lastActivationDate: '2013-08-14+01:00',
     });
   });
+  it('should reject with a ForbiddenError when the Enedis Oauth process was never done', async () => {
+    // No /enedis/finalize call: the account has no device linked to the Enedis client id
+    const response = enedisModel.getAccessToken('b2d23f66-487d-493f-8acb-9c8adb400def');
+    await assert.isRejected(response, 'Forbidden');
+  });
   it('should return 403', async () => {
     // First, finalize Enedis Oauth process
     nock(`https://${process.env.ENEDIS_BACKEND_URL}`)


### PR DESCRIPTION
## Summary

Follow-up to #231, whose `codecov/project` check was red: three lines of `core` stopped being hit after the supertest upgrade. Comparing the Codecov line reports of the base and head commits pinpointed them.

## Changes

- **`core/middleware/gladysUsage.js` line 16** truncates the `User-Agent`. supertest 3 sent a default `node-superagent/...` header on every request, supertest 7 sends none, so the `/v1/api/gladys/version` tests now set one explicitly, like a real Gladys instance does.
- **`core/enedis/enedis.js` lines 107-108** reject `getAccessToken` with a `ForbiddenError` when the account has no Enedis device. That path was only reached by accident on CI and never locally, so it now has its own test in `enedis.getContract.test.js`.

Test-only change, no production code touched.

## Test plan

- [x] Both spots are covered again in a local `nyc` run
- [x] `npm run prettier-check` and `npm run eslint` green
- [x] Full suite locally with Postgres 16 + Redis: 494 passing, same 23 secret-dependent failures as `master`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0177YUhDENZmKopWbwYjgJ7S

---
_Generated by [Claude Code](https://claude.ai/code/session_0177YUhDENZmKopWbwYjgJ7S)_